### PR TITLE
vmtests: don't fail on dmesg RIP warning

### DIFF
--- a/travis-ci/vmtest/run.sh
+++ b/travis-ci/vmtest/run.sh
@@ -444,7 +444,8 @@ else
 fi
 if [ -f "$mnt/dmesg" ]; then
         ! grep "RIP" "$mnt/dmesg" -C 20
-        exitstatus=$(($exitstatus + $?))
+        # don't fail, temporarily
+        # exitstatus=$(($exitstatus + $?))
 else
         # we don't have dmesg?
         echo -e "\nFailed to obtain dmesg from VM, looks very suspicious\n" >&2


### PR DESCRIPTION
Temporarily disable failing when RIP warning is detected in dmesg output.
Right now bpf/bpf-next trees have a known warning, so all the builds are
reported as failing, which reduces signal-to-noise ration of test results.

Signed-off-by: Andrii Nakryiko <andriin@fb.com>