### PR TITLE
vmtest: switch to Clang/LLVM 13

### DIFF
--- a/travis-ci/vmtest/build_selftests.sh
+++ b/travis-ci/vmtest/build_selftests.sh
@@ -6,7 +6,7 @@ source $(cd $(dirname $0) && pwd)/helpers.sh
 
 travis_fold start prepare_selftests "Building selftests"
 
-LLVM_VER=12
+LLVM_VER=13
 LIBBPF_PATH="${REPO_ROOT}"
 
 PREPARE_SELFTESTS_SCRIPT=${VMTEST_ROOT}/prepare_selftests-${KERNEL}.sh

--- a/travis-ci/vmtest/run_vmtest.sh
+++ b/travis-ci/vmtest/run_vmtest.sh
@@ -17,7 +17,7 @@ while [ $n -lt 5 ]; do
   wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
   echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" | sudo tee -a /etc/apt/sources.list && \
   sudo apt-get update && \
-  sudo apt-get -y install clang-12 lld-12 llvm-12 && \
+  sudo apt-get -y install clang-13 lld-13 llvm-13 && \
   set -e && \
   break
   n=$(($n + 1))


### PR DESCRIPTION
New nightly version is now 13, update all the used versions accordingly.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>