### PR TITLE
vmtest: roll back to Clang/LLVM 12

### DIFF
--- a/travis-ci/vmtest/build_selftests.sh
+++ b/travis-ci/vmtest/build_selftests.sh
@@ -6,7 +6,7 @@ source $(cd $(dirname $0) && pwd)/helpers.sh
 
 travis_fold start prepare_selftests "Building selftests"
 
-LLVM_VER=13
+LLVM_VER=12
 LIBBPF_PATH="${REPO_ROOT}"
 
 PREPARE_SELFTESTS_SCRIPT=${VMTEST_ROOT}/prepare_selftests-${KERNEL}.sh

--- a/travis-ci/vmtest/run_vmtest.sh
+++ b/travis-ci/vmtest/run_vmtest.sh
@@ -15,9 +15,9 @@ n=0
 while [ $n -lt 5 ]; do
   set +e && \
   wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
-  echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" | sudo tee -a /etc/apt/sources.list && \
+  echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-12 main" | sudo tee -a /etc/apt/sources.list && \
   sudo apt-get update && \
-  sudo apt-get -y install clang-13 lld-13 llvm-13 && \
+  sudo apt-get -y install clang-12 lld-12 llvm-12 && \
   set -e && \
   break
   n=$(($n + 1))


### PR DESCRIPTION
Clang 13 has BPF code generation regressions, so until we figure this
out and mitigate the regression, let's fix version 12 and get green builds
again.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>