### PR TITLE
Revert "vmtest: roll back to Clang/LLVM 12"

### DIFF
--- a/travis-ci/vmtest/build_selftests.sh
+++ b/travis-ci/vmtest/build_selftests.sh
@@ -6,7 +6,7 @@ source $(cd $(dirname $0) && pwd)/helpers.sh
 
 travis_fold start prepare_selftests "Building selftests"
 
-LLVM_VER=12
+LLVM_VER=13
 LIBBPF_PATH="${REPO_ROOT}"
 
 PREPARE_SELFTESTS_SCRIPT=${VMTEST_ROOT}/prepare_selftests-${KERNEL}.sh

--- a/travis-ci/vmtest/run_vmtest.sh
+++ b/travis-ci/vmtest/run_vmtest.sh
@@ -15,9 +15,9 @@ n=0
 while [ $n -lt 5 ]; do
   set +e && \
   wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
-  echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-12 main" | sudo tee -a /etc/apt/sources.list && \
+  echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" | sudo tee -a /etc/apt/sources.list && \
   sudo apt-get update && \
-  sudo apt-get -y install clang-12 lld-12 llvm-12 && \
+  sudo apt-get -y install clang-13 lld-13 llvm-13 && \
   set -e && \
   break
   n=$(($n + 1))


### PR DESCRIPTION
Nightly Clang is fixed, revert back to using the latest Clang in tests.

This reverts commit 0d796e7cef1c8c25ed0891147a74b1293d9da21f.