### PR TITLE
travis-ci: perform very shallow Git clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: bash
 dist: focal
 services:
     - docker
+git:
+    depth: 3
 
 env:
     global:


### PR DESCRIPTION
Travis CI by default clones with --depth=50, which results in unnecessarily
big amount of data fetched on every build. Currently it takes about 86 seconds
to check out the repo. Let's see if reducing the depth to 3 will save some
time and traffic.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>