### PR TITLE
ci: make sure to cancel in-flight test runs when PR is updated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,11 @@
-name: bpfci
+name: bpf-ci
 
 on:
   pull_request:
+
+concurrency: 
+  group: ci-test-${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   VM_Test:
@@ -16,4 +20,4 @@ jobs:
       - name: install
         run: sudo apt-get update && sudo apt-get install aptitude qemu-kvm zstd binutils-dev elfutils libcap-dev libelf-dev libdw-dev python3-docutils
       - name: Kernel LATEST + selftests
-        run: export REPO_ROOT=$GITHUB_WORKSPACE ; export CI_ROOT=$REPO_ROOT/travis-ci; export VMTEST_ROOT=$CI_ROOT/vmtest ; ${CI_ROOT}/vmtest/run_vmtest.sh || exit 1
+        run: export REPO_ROOT=$GITHUB_WORKSPACE; export CI_ROOT=$REPO_ROOT/travis-ci; export VMTEST_ROOT=$CI_ROOT/vmtest; ${CI_ROOT}/vmtest/run_vmtest.sh || exit 1


### PR DESCRIPTION
Use recent Github Actions' concurrency group functionality ([0]) to ensure
that we only run the latest version of a PR.

This seems to work fine for libbpf CI ([1]).

  [0] https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
  [1] https://github.com/libbpf/libbpf/commit/0db006d28efd88650dabcf85c8000d788128262a

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>