### PR TITLE
Fix output grouping

### DIFF
--- a/travis-ci/vmtest/helpers.sh
+++ b/travis-ci/vmtest/helpers.sh
@@ -17,7 +17,7 @@ travis_fold() {
         line="$line - ${YELLOW}$3${NOCOLOR}"
       fi
     else
-      line="::endgroup"
+      line="::endgroup::"
     fi
     echo -e "$line"
   fi


### PR DESCRIPTION
Github action require "::endgroup::" to close the group