### PR TITLE
ci: run script to test bpftool types/options sync

### DIFF
--- a/travis-ci/vmtest/run_selftests.sh
+++ b/travis-ci/vmtest/run_selftests.sh
@@ -28,6 +28,12 @@ test_verifier() {
 	travis_fold end test_verifier
 }
 
+bpftool_checks() {
+	travis_fold start bpftool_checks "bpftool checks"
+	./test_bpftool_synctypes.py
+	travis_fold end bpftool_checks
+}
+
 travis_fold end vm_init
 
 configs_path='libbpf/travis-ci/vmtest/configs'


### PR DESCRIPTION
### Consistency checks for bpftool

This PR adds a call to test_bpftool_synctypes.py to run_selftests.sh. The objective of this script is to make sure that the different parts of bpftool that should be updated on BPF UAPI changes (type lists, help messages, documentation, bash completion) do remain in sync between them, and with the UAPI headers from the kernel. The motivation to have it in the CI is to effectively make sure that new patchsets consistently update all those parts when necessary.

Notes:
- ~The new section in run_selftests.sh is called `Testing bpftool`, but this is not entirely correct. We don't test bpftool itself (only check that different pieces of its code are in sync), whereas _other_ scripts that are part of the BPF selftests suite _do_ test bpftool, outside of this new section. Not sure if something along `Miscellaneous checks` would be better?~

- I have tested the script itself, but not as part as the CI, because I'm not sure if they're a simple way to redeploy it to test it.

- The script itself behaves somewhat like `diff`: it is expected that no output is produced if no error is found.