### PR TITLE
ci: do run (previously defined) bpftool_checks

### DIFF
--- a/travis-ci/vmtest/run_selftests.sh
+++ b/travis-ci/vmtest/run_selftests.sh
@@ -54,4 +54,5 @@ test_progs
 if [[ "${KERNEL}" == 'latest' ]]; then
 	test_maps
 	test_verifier
+	bpftool_checks
 fi


### PR DESCRIPTION
Follow-up to https://github.com/kernel-patches/vmtest/pull/22.

We defined `bpftool_checks` but never call it: let's do so.