### PR TITLE
Enable CI testing for PRs in vmtest repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,15 @@ jobs:
       - uses: actions/checkout@v2
       - name: install
         run: sudo apt-get update && sudo apt-get install aptitude qemu-kvm zstd binutils-dev elfutils libcap-dev libelf-dev libdw-dev python3-docutils
+      - name: Get bpf-next source
+        if: ${{ github.repository != 'kernel-patches/bpf' }}
+        uses: actions/checkout@v2
+        with:
+          repository: kernel-patches/bpf
+          ref: 'bpf-next'
+          path: 'linux'
+      - name: Move linux source in place
+        if: ${{ github.repository != 'kernel-patches/bpf' }}
+        run: rsync --exclude .git -av linux/. . && rm -rf linux
       - name: Kernel LATEST + selftests
         run: export REPO_ROOT=$GITHUB_WORKSPACE; export CI_ROOT=$REPO_ROOT/travis-ci; export VMTEST_ROOT=$CI_ROOT/vmtest; ${CI_ROOT}/vmtest/run_vmtest.sh || exit 1


### PR DESCRIPTION
Adds two optional step in CI workflow that clones bpf-next tree, these steps
only runs out of "kernel-patches/bpf" repo, this will allow testing CI scripts
on vmtest repo PRs.