### PR TITLE
ci: check bpftool types/options sync (v2)

### DIFF
--- a/travis-ci/vmtest/run.sh
+++ b/travis-ci/vmtest/run.sh
@@ -378,6 +378,15 @@ LIBBPF_PATH="${REPO_ROOT}" \
 	VMTEST_ROOT="${VMTEST_ROOT}" \
 	VMLINUX_BTF=${vmlinux} ${VMTEST_ROOT}/build_selftests.sh
 
+travis_fold start bpftool_checks "Running bpftool checks..."
+if [[ "${KERNEL}" = 'LATEST' ]]; then
+	"${REPO_ROOT}/tools/testing/selftests/bpf/test_bpftool_synctypes.py" && \
+		echo "Consistency checks passed successfully."
+else
+	echo "Consistency checks skipped."
+fi
+travis_fold end bpftool_checks
+
 travis_fold start vm_init "Starting virtual machine..."
 
 if (( SKIPSOURCE )); then

--- a/travis-ci/vmtest/run_selftests.sh
+++ b/travis-ci/vmtest/run_selftests.sh
@@ -28,12 +28,6 @@ test_verifier() {
 	travis_fold end test_verifier
 }
 
-bpftool_checks() {
-	travis_fold start bpftool_checks "bpftool checks"
-	./test_bpftool_synctypes.py
-	travis_fold end bpftool_checks
-}
-
 travis_fold end vm_init
 
 configs_path='libbpf/travis-ci/vmtest/configs'


### PR DESCRIPTION
This is another take at #22 and #23 (reverted in this PR and #24, respectively, because we currently have no Python3 installed in the VM image).

Things should go better this time, since we have the equivalent PR working in libbpf at https://github.com/libbpf/libbpf/pull/352.
