### PR TITLE
Set timeout to 1.5H instead of default 6H

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ concurrency:
 
 jobs:
   VM_Test:
+    timeout-minutes: 100
     runs-on: ubuntu-latest
     env:
       PROJECT_NAME: 'libbpf'


### PR DESCRIPTION
the normal runtime is about 40-50minutes, there should be still plenty of room