### PR TITLE
[ci] Add temporary patch fix for bpf tree

### DIFF
--- a/travis-ci/vmtest/diffs/0002-x86-setup-Explicitly-include-acpi.h.patch
+++ b/travis-ci/vmtest/diffs/0002-x86-setup-Explicitly-include-acpi.h.patch
@@ -1,0 +1,56 @@
+From ea7b4244b3656ca33b19a950f092b5bbc718b40c Mon Sep 17 00:00:00 2001
+From: Nathan Chancellor <nathan@kernel.org>
+Date: Wed, 1 Sep 2021 09:07:01 -0700
+Subject: [PATCH] x86/setup: Explicitly include acpi.h
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+After commit 342f43af70db ("iscsi_ibft: fix crash due to KASLR physical
+memory remapping") x86_64_defconfig shows the following errors:
+
+  arch/x86/kernel/setup.c: In function ‘setup_arch’:
+  arch/x86/kernel/setup.c:916:13: error: implicit declaration of function ‘acpi_mps_check’ [-Werror=implicit-function-declaration]
+    916 |         if (acpi_mps_check()) {
+        |             ^~~~~~~~~~~~~~
+  arch/x86/kernel/setup.c:1110:9: error: implicit declaration of function ‘acpi_table_upgrade’ [-Werror=implicit-function-declaration]
+   1110 |         acpi_table_upgrade();
+        |         ^~~~~~~~~~~~~~~~~~
+  [... more acpi noise ...]
+
+acpi.h was being implicitly included from iscsi_ibft.h in this
+configuration so the removal of that header means these functions have
+no definition or declaration.
+
+In most other configurations, <linux/acpi.h> continued to be included
+through at least <linux/tboot.h> if CONFIG_INTEL_TXT was enabled, and
+there were probably other implicit include paths too.
+
+Add acpi.h explicitly so there is no more error, and so that we don't
+continue to depend on these unreliable implicit include paths.
+
+Tested-by: Matthieu Baerts <matthieu.baerts@tessares.net>
+Signed-off-by: Nathan Chancellor <nathan@kernel.org>
+Cc: Maurizio Lombardi <mlombard@redhat.com>
+Cc: Mike Rapoport <rppt@linux.ibm.com>
+Cc: Konrad Rzeszutek Wilk <konrad@kernel.org>
+Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
+---
+ arch/x86/kernel/setup.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/x86/kernel/setup.c b/arch/x86/kernel/setup.c
+index 63b20536c8d2..79f164141116 100644
+--- a/arch/x86/kernel/setup.c
++++ b/arch/x86/kernel/setup.c
+@@ -5,6 +5,7 @@
+  * This file contains the setup_arch() code, which handles the architecture-dependent
+  * parts of early kernel initialization.
+  */
++#include <linux/acpi.h>
+ #include <linux/console.h>
+ #include <linux/crash_dump.h>
+ #include <linux/dma-map-ops.h>
+-- 
+2.30.2
+


### PR DESCRIPTION
Add ea7b4244b365 ("x86/setup: Explicitly include acpi.h") to fix bpf tree
build.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>