### PR TITLE
Reverse condition for copying the Linux sources

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,14 +21,14 @@ jobs:
       - name: install
         run: sudo apt-get update && sudo apt-get install aptitude qemu-kvm zstd binutils-dev elfutils libcap-dev libelf-dev libdw-dev python3-docutils
       - name: Get bpf-next source
-        if: ${{ github.repository != 'kernel-patches/bpf' }}
+        if: ${{ github.repository == 'kernel-patches/vmtest' }}
         uses: actions/checkout@v2
         with:
           repository: kernel-patches/bpf
           ref: 'bpf-next'
           path: 'linux'
       - name: Move linux source in place
-        if: ${{ github.repository != 'kernel-patches/bpf' }}
+        if: ${{ github.repository == 'kernel-patches/vmtest' }}
         run: rsync --exclude .git -av linux/. . && rm -rf linux
       - name: Kernel LATEST + selftests
         run: export REPO_ROOT=$GITHUB_WORKSPACE; export CI_ROOT=$REPO_ROOT/travis-ci; export VMTEST_ROOT=$CI_ROOT/vmtest; ${CI_ROOT}/vmtest/run_vmtest.sh || exit 1


### PR DESCRIPTION
Context: https://github.com/kernel-patches/vmtest/issues/41

> kernel-patches/vmtest is an exception here, not the kernel-patches/bpf

We don't want a hardcoded condition on `kernel-patches/bpf` to enable the CI for vmtest, because it makes it harder to reuse the CI on different repos in the future (think net/net-next) or on different forks of bpf-next. Instead, let's copy the sources only when running the GitHub Action on the kernel-patches/vmtest repository.

Next step should be to create a separate .yml workflow description, specific to kernel-patches/vmtest.