### PR TITLE
ci: return with non-zero status code if bpftool checks fail

### DIFF
--- a/travis-ci/vmtest/run.sh
+++ b/travis-ci/vmtest/run.sh
@@ -431,8 +431,7 @@ sudo chmod 755 "$mnt/etc/rcS.d/S50-run-tests"
 
 poweroff_script="#!/bin/sh
 
-echo travis_fold:start:shutdown
-echo -e '\033[1;33mShutdown\033[0m\n'
+echo -e '$(travis_fold start shutdown Shutdown)'
 
 poweroff"
 echo "${poweroff_script}" | sudo tee "$mnt/etc/rcS.d/S99-poweroff" > /dev/null

--- a/travis-ci/vmtest/run.sh
+++ b/travis-ci/vmtest/run.sh
@@ -378,10 +378,20 @@ LIBBPF_PATH="${REPO_ROOT}" \
 	VMTEST_ROOT="${VMTEST_ROOT}" \
 	VMLINUX_BTF=${vmlinux} ${VMTEST_ROOT}/build_selftests.sh
 
+declare -A test_results
+
 travis_fold start bpftool_checks "Running bpftool checks..."
 if [[ "${KERNEL}" = 'LATEST' ]]; then
-	"${REPO_ROOT}/tools/testing/selftests/bpf/test_bpftool_synctypes.py" && \
-		echo "Consistency checks passed successfully."
+	# "&& true" does not change the return code (it is not executed if the
+	# Python script fails), but it prevents the trap on ERR set at the top
+	# of this file to trigger on failure.
+	"${REPO_ROOT}/tools/testing/selftests/bpf/test_bpftool_synctypes.py" && true
+	test_results["bpftool"]=$?
+	if [[ ${test_results["bpftool"]} -eq 0 ]]; then
+		echo "::notice title=bpftool_checks::bpftool checks passed successfully."
+	else
+		echo "::error title=bpftool_checks::bpftool checks returned ${test_results["bpftool"]}."
+	fi
 else
 	echo "Consistency checks skipped."
 fi
@@ -466,5 +476,22 @@ fi
 sudo umount "$mnt"
 
 travis_fold end shutdown
+
+test_results["vm_tests"]=$exitstatus
+
+# Final summary - Don't use a fold, keep it visible
+echo -e "\033[1;33mTest Results:\033[0m"
+for testgroup in ${!test_results[@]}; do
+	# Print final result for each group of tests
+	if [[ ${test_results[$testgroup]} -eq 0 ]]; then
+		printf "%20s: \033[1;32mPASS\033[0m\n" $testgroup
+	else
+		printf "%20s: \033[1;31mFAIL\033[0m\n" $testgroup
+	fi
+	# Make exitstatus > 0 if at least one test group has failed
+	if [[ ${test_results[$testgroup]} -ne 0 ]]; then
+		exitstatus=1
+	fi
+done
 
 exit "$exitstatus"


### PR DESCRIPTION
The bpftool checks work as expected when the CI runs, except that they do not set any error status code for the script on error, which means that the failures are lost among the logs and not reported in a clear way to the reviewers.

Let's account for the status of bpftool checks when exiting from run.sh

[EDIT] Let's also create a summary for the different group tests, at the end of the test logs, under the folded sections. This summary may be extended in the future with a more detailed overview of the tests running in the VM.

**Warning:** Submitted as a PR for discussion and for validation through the CI. Before merging, we should address the current inconsistencies reported by `test_bpftool_synctypes.py`, or we will cause the next CI runs to fail.
