### PR TITLE
Split results per group of selftests in final summary

### DIFF
--- a/travis-ci/vmtest/helpers.sh
+++ b/travis-ci/vmtest/helpers.sh
@@ -22,3 +22,23 @@ travis_fold() {
     echo -e "$line"
   fi
 }
+
+__print() {
+  local TITLE=""
+  if [[ -n $2 ]]; then
+      TITLE=" title=$2"
+  fi
+  echo "::$1${TITLE}::$3"
+}
+
+# $1 - title
+# $2 - message
+print_error() {
+  __print error $1 $2
+}
+
+# $1 - title
+# $2 - message
+print_notice() {
+  __print notice $1 $2
+}

--- a/travis-ci/vmtest/run.sh
+++ b/travis-ci/vmtest/run.sh
@@ -388,9 +388,9 @@ if [[ "${KERNEL}" = 'LATEST' ]]; then
 	"${REPO_ROOT}/tools/testing/selftests/bpf/test_bpftool_synctypes.py" && true
 	test_results["bpftool"]=$?
 	if [[ ${test_results["bpftool"]} -eq 0 ]]; then
-		echo "::notice title=bpftool_checks::bpftool checks passed successfully."
+		print_notice bpftool_checks "bpftool checks passed successfully."
 	else
-		echo "::error title=bpftool_checks::bpftool checks returned ${test_results["bpftool"]}."
+		print_error bpftool_checks "bpftool checks returned ${test_results["bpftool"]}."
 	fi
 else
 	echo "Consistency checks skipped."

--- a/travis-ci/vmtest/run_selftests.sh
+++ b/travis-ci/vmtest/run_selftests.sh
@@ -4,27 +4,36 @@ set -euo pipefail
 
 source $(cd $(dirname $0) && pwd)/helpers.sh
 
+STATUS_FILE=/exitstatus
+
 test_progs() {
 	if [[ "${KERNEL}" != '4.9.0' ]]; then
 		travis_fold start test_progs "Testing test_progs"
-		./test_progs ${BLACKLIST:+-b$BLACKLIST} ${WHITELIST:+-t$WHITELIST}
+		# "&& true" does not change the return code (it is not executed
+		# if the Python script fails), but it prevents exiting on a
+		# failure due to the "set -e".
+		./test_progs ${BLACKLIST:+-b$BLACKLIST} ${WHITELIST:+-t$WHITELIST} && true
+		echo "test_progs:$?" >> "${STATUS_FILE}"
 		travis_fold end test_progs
 	fi
 
 	travis_fold start test_progs-no_alu32 "Testing test_progs-no_alu32"
-	./test_progs-no_alu32 ${BLACKLIST:+-b$BLACKLIST} ${WHITELIST:+-t$WHITELIST}
+	./test_progs-no_alu32 ${BLACKLIST:+-b$BLACKLIST} ${WHITELIST:+-t$WHITELIST} && true
+	echo "test_progs-no_alu32:$?" >> "${STATUS_FILE}"
 	travis_fold end test_progs-no_alu32
 }
 
 test_maps() {
 	travis_fold start test_maps "Testing test_maps"
-	./test_maps
+	./test_maps && true
+	echo "test_maps:$?" >> "${STATUS_FILE}"
 	travis_fold end test_maps
 }
 
 test_verifier() {
 	travis_fold start test_verifier "Testing test_verifier"
-	./test_verifier
+	./test_verifier && true
+	echo "test_verifier:$?" >> "${STATUS_FILE}"
 	travis_fold end test_verifier
 }
 

--- a/travis-ci/vmtest/run_vmtest.sh
+++ b/travis-ci/vmtest/run_vmtest.sh
@@ -33,11 +33,12 @@ travis_fold end install_clang
 # Build selftests (and latest kernel, if necessary)
 KERNEL="${KERNEL}" ${VMTEST_ROOT}/prepare_selftests.sh
 
-
+travis_fold start adduser_to_kvm "Add user ${USER}"
+sudo adduser "${USER}" kvm
+travis_fold stop adduser_to_kvm
 
 # Escape whitespace characters.
 setup_cmd=$(sed 's/\([[:space:]]\)/\\\1/g' <<< "${VMTEST_SETUPCMD}")
-sudo adduser "${USER}" kvm
 
 if [[ "${KERNEL}" = 'LATEST' ]]; then
   sudo -E sudo -E -u "${USER}" "${VMTEST_ROOT}/run.sh" -b "${REPO_ROOT}"  -o -d ~ -s "${setup_cmd}" ~/root.img;


### PR DESCRIPTION
As a follow-up to the recent introduction of a “final summary” of the selftest results in the CI Action logs, make the different groups of selftests (`test_progs`, `test_progs-no_alu32`, `test_maps`, `test_verifier`) print their results individually.

To do:
- [ ] Validate that the changes work as intended
- [ ] Twin PR for libbpf