### PR TITLE
use "-j" for test_progs if core count is over than 2

### DIFF
--- a/travis-ci/vmtest/run_selftests.sh
+++ b/travis-ci/vmtest/run_selftests.sh
@@ -6,17 +6,22 @@ source $(cd $(dirname $0) && pwd)/helpers.sh
 
 STATUS_FILE=/exitstatus
 
+TEST_PROGS_ARGS=""
+if [[ "$(nproc)" -gt 2 ]]; then
+  TEST_PROGS_ARGS="-j"
+fi
+
 test_progs() {
   travis_fold start test_progs "Testing test_progs"
   # "&& true" does not change the return code (it is not executed
   # if the Python script fails), but it prevents exiting on a
   # failure due to the "set -e".
-  ./test_progs ${BLACKLIST:+-b$BLACKLIST} ${WHITELIST:+-t$WHITELIST} && true
+  ./test_progs ${BLACKLIST:+-b$BLACKLIST} ${WHITELIST:+-t$WHITELIST} ${TEST_PROGS_ARGS} && true
   echo "test_progs:$?" >>"${STATUS_FILE}"
   travis_fold end test_progs
 
   travis_fold start test_progs-no_alu32 "Testing test_progs-no_alu32"
-  ./test_progs-no_alu32 ${BLACKLIST:+-b$BLACKLIST} ${WHITELIST:+-t$WHITELIST} && true
+  ./test_progs-no_alu32 ${BLACKLIST:+-b$BLACKLIST} ${WHITELIST:+-t$WHITELIST} ${TEST_PROGS_ARGS} && true
   echo "test_progs-no_alu32:$?" >>"${STATUS_FILE}"
   travis_fold end test_progs-no_alu32
 }


### PR DESCRIPTION
This will make CI run faster on new self-hosted runner with more cpus