### PR TITLE
run_selftests: limit test_maps parallelism to avoid OOM

### DIFF
--- a/travis-ci/vmtest/run_selftests.sh
+++ b/travis-ci/vmtest/run_selftests.sh
@@ -29,7 +29,7 @@ test_progs() {
 
 test_maps() {
   travis_fold start test_maps "Testing test_maps"
-  ./test_maps && true
+  taskset 0xF ./test_maps && true
   echo "test_maps:$?" >>"${STATUS_FILE}"
   travis_fold end test_maps
 }


### PR DESCRIPTION
Limit test_maps to running on at most 4 CPUs to avoid excessive memory
usage due to a storm of BPF maps created rapidly on lots of CPU cores.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>