### PR TITLE
ci: blacklist tests relying on multi-kprobe

### DIFF
--- a/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest
+++ b/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest
@@ -1,2 +1,4 @@
 # TEMPORARY
-tc_bpf
+bpf_cookie
+kprobe_multi_test
+


### PR DESCRIPTION
Multi-kprobe is currently not implemented on x86-64, so blacklist them
temporarily.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>