### PR TITLE
ci: unblacklist multi-kprobe tests

### DIFF
--- a/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest
+++ b/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest
@@ -1,4 +1,2 @@
 # TEMPORARY
-bpf_cookie
-kprobe_multi_test
 


### PR DESCRIPTION
Now that x86-64 implementation of multi-kprobe landed, enable selftests
again.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>