### PR TITLE
ci: blacklist attach_probe and uprobe_autoattach tests on s390x

### DIFF
--- a/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest.s390x
+++ b/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest.s390x
@@ -62,3 +62,5 @@ bpf_cookie                               # failed to open_and_load program: -524
 xdp_do_redirect                          # prog_run_max_size unexpected error: -22 (errno 22)
 send_signal                              # intermittently fails to receive signal
 select_reuseport                         # intermittently fails on new s390x setup
+attach_probe                             # uprobe subtests are broken on s390x
+uprobe_autoattach                        # uprobe subtests are broken on s390x


### PR DESCRIPTION
libc.so.6 can't be currently resolved in CI for s390x arch.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>