### PR TITLE
ci: blacklist xdp_syncookie on s390x

### DIFF
--- a/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest.s390x
+++ b/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest.s390x
@@ -63,3 +63,4 @@ xdp_do_redirect                          # prog_run_max_size unexpected error: -
 send_signal                              # intermittently fails to receive signal
 select_reuseport                         # intermittently fails on new s390x setup
 tc_redirect/tc_redirect_dtime            # very flaky
+xdp_synproxy                             # JIT does not support calling kernel function                                (kfunc)


### PR DESCRIPTION
The xdp_syncookie test uses kfunc, and BPF JIT doesn't support kfunc on
s390x.

Signed-off-by: Maxim Mikityanskiy <maximmi@nvidia.com>