### PR TITLE
ci: blacklist mptcp test on s390x, kprobe_multi_test/bench_attach everywhere

### DIFF
--- a/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest
+++ b/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest
@@ -1,2 +1,3 @@
 # TEMPORARY
 btf_dump/btf_dump: syntax
+kprobe_multi_test/bench_attach

--- a/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest.s390x
+++ b/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest.s390x
@@ -25,6 +25,7 @@ ksyms_module_libbpf                      # JIT does not support calling kernel f
 ksyms_module_lskel                       # test_ksyms_module_lskel__open_and_load unexpected error: -9                 (?)
 modify_return                            # modify_return attach failed: -524                                           (trampoline)
 module_attach                            # skel_attach skeleton attach failed: -524                                    (trampoline)
+mptcp
 kprobe_multi_test                        # relies on fentry
 netcnt                                   # failed to load BPF skeleton 'netcnt_prog': -7                               (?)
 probe_user                               # check_kprobe_res wrong kprobe res from probe read                           (?)


### PR DESCRIPTION
Another set of fixes for CI.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>