### PR TITLE
ci: blacklist unpriv_bpf_disabled on s390x due to BPF trampoline use

### DIFF
--- a/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest.s390x
+++ b/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest.s390x
@@ -65,3 +65,4 @@ send_signal                              # intermittently fails to receive signa
 select_reuseport                         # intermittently fails on new s390x setup
 tc_redirect/tc_redirect_dtime            # very flaky
 xdp_synproxy                             # JIT does not support calling kernel function                                (kfunc)
+unpriv_bpf_disabled                      # fentry


### PR DESCRIPTION
Another test with BPF trampoline dependency. BPF trampoline isn't
supported by s390x.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>