### PR TITLE
ci: temporary fix for selftest stacktrace_build_id

### DIFF
--- a/travis-ci/diffs/0001-selftests-bpf-fix-stacktrace_build_id-with-missing-k.diff
+++ b/travis-ci/diffs/0001-selftests-bpf-fix-stacktrace_build_id-with-missing-k.diff
@@ -1,0 +1,43 @@
+From 0744fe5996e977b7a1634504b6a77426f6384bbe Mon Sep 17 00:00:00 2001
+From: Song Liu <song@kernel.org>
+Date: Thu, 26 May 2022 12:06:12 -0700
+Subject: [PATCH bpf] selftests/bpf: fix stacktrace_build_id with missing
+ kprobe/urandom_read
+
+Kernel function urandom_read is replaced with urandom_read_iter.
+Therefore, kprobe on urandom_read is not working any more:
+
+[root@eth50-1 bpf]# ./test_progs -n 161
+test_stacktrace_build_id:PASS:skel_open_and_load 0 nsec
+libbpf: kprobe perf_event_open() failed: No such file or directory
+libbpf: prog 'oncpu': failed to create kprobe 'urandom_read+0x0' \
+        perf event: No such file or directory
+libbpf: prog 'oncpu': failed to auto-attach: -2
+test_stacktrace_build_id:FAIL:attach_tp err -2
+161     stacktrace_build_id:FAIL
+
+Fix this by replacing urandom_read with urandom_read_iter in the test.
+
+Fixes: 1b388e7765f2 ("random: convert to using fops->read_iter()")
+Reported-by: Mykola Lysenko <mykolal@fb.com>
+Signed-off-by: Song Liu <song@kernel.org>
+---
+ tools/testing/selftests/bpf/progs/test_stacktrace_build_id.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/testing/selftests/bpf/progs/test_stacktrace_build_id.c b/tools/testing/selftests/bpf/progs/test_stacktrace_build_id.c
+index 6c62bfb8bb6f..0c4426592a26 100644
+--- a/tools/testing/selftests/bpf/progs/test_stacktrace_build_id.c
++++ b/tools/testing/selftests/bpf/progs/test_stacktrace_build_id.c
+@@ -39,7 +39,7 @@ struct {
+ 	__type(value, stack_trace_t);
+ } stack_amap SEC(".maps");
+ 
+-SEC("kprobe/urandom_read")
++SEC("kprobe/urandom_read_iter")
+ int oncpu(struct pt_regs *args)
+ {
+ 	__u32 max_len = sizeof(struct bpf_stack_build_id)
+-- 
+2.30.2
+


### PR DESCRIPTION
Temporarily "backport" the fix before the actual fix lands in bpf tree.

Signed-off-by: Song Liu <song@kernel.org>