### PR TITLE
ci: blacklist enum64 tests temporarily

### DIFF
--- a/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest
+++ b/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest
@@ -1,3 +1,4 @@
 # TEMPORARY
 btf_dump/btf_dump: syntax
 kprobe_multi_test/bench_attach
+core_reloc/enum64val


### PR DESCRIPTION
Waiting for Clang nightly to be updated with ENUM64 support.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>