### PR TITLE
ci: blacklist few core_reloc subtests which got ENUM64s in them

### DIFF
--- a/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest
+++ b/travis-ci/vmtest/configs/blacklist/BLACKLIST-latest
@@ -3,3 +3,5 @@ btf_dump/btf_dump: syntax
 kprobe_multi_test/bench_attach
 core_reloc/enum64val
 varlen
+core_reloc/size___diff_sz
+core_reloc/type_based___diff_sz


### PR DESCRIPTION
Newest Clang emits ENUM64 types, but bpf tree doesn't yet have libbpf
that can handle them.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>