### PR TITLE
Reverse condition for copying the Linux sources

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,12 +35,12 @@ jobs:
       REPO_PATH: ""
     steps:
       - uses: actions/checkout@v2
-      - if: ${{ github.repository != 'kernel-patches/bpf' && github.repository != 'kernel-patches/bpf-rc' }}
+      - if: ${{ github.repository == 'kernel-patches/vmtest' }}
         name: Download bpf-next tree
         uses: libbpf/ci/get-linux-source@master
         with:
           dest: '.kernel'
-      - if: ${{ github.repository != 'kernel-patches/bpf' && github.repository != 'kernel-patches/bpf-rc' }}
+      - if: ${{ github.repository == 'kernel-patches/vmtest' }}
         name: Move linux source in place
         shell: bash
         run: |


### PR DESCRIPTION
This patch was applied before as cd9dc8915cb4, but reverted by mistake
in 7487c6523cc9.

Context: https://github.com/kernel-patches/vmtest/issues/41

> kernel-patches/vmtest is an exception here, not the kernel-patches/bpf

We don't want a hardcoded condition on `kernel-patches/bpf` to enable
the CI for vmtest, because it makes it harder to reuse the CI on
different repos in the future (think net/net-next) or on different forks
of bpf-next. Instead, let's copy the sources only when running the
GitHub Action on the kernel-patches/vmtest repository.

Next step should be to create a separate .yml workflow description,
specific to kernel-patches/vmtest.

Fixes: fa07d13393d0 ("Enable CI testing for PRs in vmtest repo")
Signed-off-by: Paul Chaignon <paul@cilium.io>
Signed-off-by: Quentin Monnet <quentin@isovalent.com>
cc @qmonnet 