### PR TITLE
Remove setting of AUTHOR_EMAIL environment variable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,6 @@ jobs:
             arch: 's390x'
             toolchain: 'gcc'
     env:
-      AUTHOR_EMAIL: "$(git log -1 --pretty=\"%aE\")"
       KERNEL: LATEST
       REPO_ROOT: ${{ github.workspace }}
       REPO_PATH: ""


### PR DESCRIPTION
This change removes the setting of the AUTHOR_EMAIL variable. To the
degree I can tell, this variable is not used. A successful CI run
without it confirmed this suspicion.

Signed-off-by: Daniel Müller <deso@posteo.net>