### PR TITLE
Run on self-hosted runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,15 +17,15 @@ jobs:
       matrix:
         include:
           - kernel: 'LATEST'
-            runs_on: ubuntu-latest
+            runs_on: [ubuntu-latest, self-hosted]
             arch: 'x86_64'
             toolchain: 'gcc'
           - kernel: 'LATEST'
-            runs_on: ubuntu-latest
+            runs_on: [ubuntu-latest, self-hosted]
             arch: 'x86_64'
             toolchain: 'llvm-15'
           - kernel: 'LATEST'
-            runs_on: z15
+            runs_on: [z15, self-hosted]
             arch: 's390x'
             toolchain: 'gcc'
     env:


### PR DESCRIPTION
We have seen cases of timeouts in the CI where a GitHub-hosted runner
was used for test execution and that slowed down everything from setup
to kernel build to running of tests.
Given that we have sufficient EC2 runners, which are beefier than
GitHub-hosted ones and, hence, can execute runs in a more timely fashion
and with fewer chances for timeouts, let's make sure to only use
self-hosted runners.
The self-hosted label is automatically assigned to all self-hosted
runners [0]. With this change we make sure to execute jobs only where
this label is present.

[0] https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-self-hosted-runners

Signed-off-by: Daniel Müller <deso@posteo.net>