### PR TITLE
Add support for allow/deny list additions

### DIFF
--- a/travis-ci/vmtest/configs/DENYLIST
+++ b/travis-ci/vmtest/configs/DENYLIST
@@ -1,0 +1,5 @@
+btf_dump/btf_dump: syntax
+kprobe_multi_test/bench_attach
+core_reloc/enum64val
+core_reloc/size___diff_sz
+core_reloc/type_based___diff_sz

--- a/travis-ci/vmtest/run_selftests.sh
+++ b/travis-ci/vmtest/run_selftests.sh
@@ -60,8 +60,19 @@ zcat /proc/config.gz
 foldable end kernel_config
 
 configs_path=${PROJECT_NAME}/selftests/bpf
-DENYLIST=$(read_lists "$configs_path/DENYLIST" "$configs_path/DENYLIST.${ARCH}")
-ALLOWLIST=$(read_lists "$configs_path/ALLOWLIST" "$configs_path/ALLOWLIST.${ARCH}")
+local_configs_path=${PROJECT_NAME}/vmtest/configs
+DENYLIST=$(read_lists \
+	"$configs_path/DENYLIST" \
+	"$configs_path/DENYLIST.${ARCH}" \
+	"$local_configs_path/DENYLIST" \
+	"$local_configs_path/DENYLIST.${ARCH}" \
+)
+ALLOWLIST=$(read_lists \
+	"$configs_path/ALLOWLIST" \
+	"$configs_path/ALLOWLIST.${ARCH}" \
+	"$local_configs_path/ALLOWLIST" \
+	"$local_configs_path/ALLOWLIST.${ARCH}" \
+)
 
 cd ${PROJECT_NAME}/selftests/bpf
 


### PR DESCRIPTION
We would like to have the possibility of quickly adding additional allow
or deny lists compared to what the upstream kernel already provides.
This change introduces the infrastructure for doing so. It also brings
back the non-architecture specific deny list removed by fba2b3da955c8
("Use deny/allow lists from upstream") which constitutes the difference
over what upstream Linux now contains, as we have seen increased
flakiness in recent CI runs.

Signed-off-by: Daniel Müller <deso@posteo.net>