### PR TITLE
ci: fix printing of currently used configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   VM_Test:
     runs-on: ${{ matrix.runs_on }}
-    name: Kernel ${{ matrix.kernel }} on ${{ matrix.runs_on }} with ${{ matrix.toolchain }}
+    name: Kernel ${{ matrix.kernel }} on ${{ matrix.runs_on[0] }} with ${{ matrix.toolchain }}
     timeout-minutes: 100
     strategy:
       fail-fast: false


### PR DESCRIPTION
We started to use array of tags during the CI
configuration print, but GH actions do not expand
array and just print 'Array' literal which is
confusing

Signed-off-by: Mykola Lysenko <mykolal@fb.com>