### PR TITLE
Bump LLVM version we use to 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           - kernel: 'LATEST'
             runs_on: [ubuntu-latest, self-hosted]
             arch: 'x86_64'
-            toolchain: 'llvm-15'
+            toolchain: 'llvm-16'
           - kernel: 'LATEST'
             runs_on: [z15, self-hosted]
             arch: 's390x'


### PR DESCRIPTION
Development on LLVM 16 has started and version 15 is no longer available
in the repository we install it from. Bump the version we use
accordingly.

Signed-off-by: Daniel Müller <deso@posteo.net>