### PR TITLE
Use pattern match for allow/deny list logic

### DIFF
--- a/travis-ci/vmtest/run_selftests.sh
+++ b/travis-ci/vmtest/run_selftests.sh
@@ -27,12 +27,12 @@ test_progs() {
   # "&& true" does not change the return code (it is not executed
   # if the Python script fails), but it prevents exiting on a
   # failure due to the "set -e".
-  ./test_progs ${DENYLIST:+-b"$DENYLIST"} ${ALLOWLIST:+-t"$ALLOWLIST"} ${TEST_PROGS_ARGS} && true
+  ./test_progs ${DENYLIST:+-d"$DENYLIST"} ${ALLOWLIST:+-a"$ALLOWLIST"} ${TEST_PROGS_ARGS} && true
   echo "test_progs:$?" >>"${STATUS_FILE}"
   foldable end test_progs
 
   foldable start test_progs-no_alu32 "Testing test_progs-no_alu32"
-  ./test_progs-no_alu32 ${DENYLIST:+-b"$DENYLIST"} ${ALLOWLIST:+-t"$ALLOWLIST"} ${TEST_PROGS_ARGS} && true
+  ./test_progs-no_alu32 ${DENYLIST:+-d"$DENYLIST"} ${ALLOWLIST:+-a"$ALLOWLIST"} ${TEST_PROGS_ARGS} && true
   echo "test_progs-no_alu32:$?" >>"${STATUS_FILE}"
   foldable end test_progs-no_alu32
 }


### PR DESCRIPTION
We support excluding and including of tests in CI runs based on deny and
allow lists, respectively, maintained in separate files. Currently these
lists are fed to test_progs via the -b (and -t) argument. This argument
is evaluated as sub-string match, meaning that for the string 'align',
for example, it would prevent both 'align-8' and 'misaligned' from
running (if deny-listed). Most of the time that's not what we want: we'd
rather specify complete names. If the desire truly is for an entry to
match multiple items, that should be made more explicit via the usage of
pattern/wildcard syntax.
With this change we switch over to using -d/-a for passing deny and
allow information to the program, which treats arguments as exact
strings, but optionally allows for wildcard usage.

Signed-off-by: Daniel Müller <deso@posteo.net>