### PR TITLE
Replace hardcoded LLVM version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  llvm-toolchain:
+    runs-on: ubuntu-latest
+    outputs:
+      llvm: ${{ steps.llvm-toolchain-impl.outputs.version }}
+    steps:
+      - id: llvm-version
+        uses: libbpf/ci/get-llvm-version@master
+      - id: llvm-toolchain-impl
+        shell: bash
+        run: echo "::set-output name=version::llvm-${{ steps.llvm-version.outputs.version }}"
   VM_Test:
+    needs: llvm-toolchain
     runs-on: ${{ matrix.runs_on }}
     name: Kernel ${{ matrix.kernel }} on ${{ matrix.runs_on[0] }} with ${{ matrix.toolchain }}
     timeout-minutes: 100
@@ -23,7 +34,7 @@ jobs:
           - kernel: 'LATEST'
             runs_on: [ubuntu-latest, self-hosted]
             arch: 'x86_64'
-            toolchain: 'llvm-16'
+            toolchain: ${{ needs.llvm-toolchain.outputs.llvm }}
           - kernel: 'LATEST'
             runs_on: [z15, self-hosted]
             arch: 's390x'


### PR DESCRIPTION
Whenever the current LLVM version is bumped, we have to adjust the
version to use in CI, because snapshot packages of the previous version
may be removed from distribution repositories and can no longer be
installed. Furthermore, this adjustment has to happen across
repositories and there are dependencies between them, making the process
tricky and partly serial and the changes non-atomic.
With recent changes we have introduced an action that contains the LLVM
version to use in an action in the central libbpf/ci repository that
constitutes the source of truth.
With this change we make use of this action to determine the LLVM
toolchain with which to work.

Signed-off-by: Daniel Müller <deso@posteo.net>