### PR TITLE
Make job matrix reusable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,27 +18,27 @@ jobs:
       - id: llvm-toolchain-impl
         shell: bash
         run: echo "::set-output name=version::llvm-${{ steps.llvm-version.outputs.version }}"
-  VM_Test:
+  set-matrix:
     needs: llvm-toolchain
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          echo "::set-output name=matrix::{\"include\":[ \
+            {\"kernel\": \"LATEST\", \"runs_on\": [\"ubuntu-latest\", \"self-hosted\"], \"arch\": \"x86_64\", \"toolchain\": \"gcc\"}, \
+            {\"kernel\": \"LATEST\", \"runs_on\": [\"ubuntu-latest\", \"self-hosted\"], \"arch\": \"x86_64\", \"toolchain\": \"${{ needs.llvm-toolchain.outputs.llvm }}\"}, \
+            {\"kernel\": \"LATEST\", \"runs_on\": [\"z15\", \"self-hosted\"], \"arch\": \"s390x\", \"toolchain\": \"gcc\"} \
+          ]}"
+  VM_Test:
+    needs: set-matrix
     runs-on: ${{ matrix.runs_on }}
     name: Kernel ${{ matrix.kernel }} on ${{ matrix.runs_on[0] }} with ${{ matrix.toolchain }}
     timeout-minutes: 100
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - kernel: 'LATEST'
-            runs_on: [ubuntu-latest, self-hosted]
-            arch: 'x86_64'
-            toolchain: 'gcc'
-          - kernel: 'LATEST'
-            runs_on: [ubuntu-latest, self-hosted]
-            arch: 'x86_64'
-            toolchain: ${{ needs.llvm-toolchain.outputs.llvm }}
-          - kernel: 'LATEST'
-            runs_on: [z15, self-hosted]
-            arch: 's390x'
-            toolchain: 'gcc'
+      matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
     env:
       KERNEL: LATEST
       REPO_ROOT: ${{ github.workspace }}


### PR DESCRIPTION
We run tests in various configurations: on x86_64 and s390x, with gcc
and clang toolchains. To define the setups to use we rely on the job
matrix feature of GitHub Actions [0].
In the future we would like to run the selftests in parallel in an
attempt to minimize overall CI runtime. As a first step towards getting
there, we want the running of selftests to be a separate job after the
building step.
Both running and building need to honor the job matrix, but GitHub
Actions does not allow us to simple configure the same matrix for
multiple jobs.
In order to make that possible, this change uses the job output feature
to "generate" the matrix, which can subsequently be used from various
locations (including different jobs). To make that work in the job
context, we now have to define the matrix in JSON and then decode it
when setting. The approach is inspired by the corresponding community
discussion [1].
As a side note, having the matrix "generated" like this is also the only
way I am aware of with which we can address the feedback received [2]
about potential conditional usage of self-hosted runners, depending on
which repository a GitHub Actions run is initiated from.

[0] https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs
[1] https://github.com/orgs/community/discussions/26284
[2] https://github.com/kernel-patches/vmtest/pull/103

Signed-off-by: Daniel Müller <deso@posteo.net>