### PR TITLE
Use matrix.kernel instead of hardcoding LATEST

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
     env:
-      KERNEL: LATEST
+      KERNEL: ${{ matrix.kernel }}
       REPO_ROOT: ${{ github.workspace }}
       REPO_PATH: ""
     steps:


### PR DESCRIPTION
Our CI job matrix already includes the kernel version we run on, so
there is no need for us to hard code the string 'LATEST' explicitly
later on. Use the matrix defined version instead.

Signed-off-by: Daniel Müller <deso@posteo.net>