### PR TITLE
Print allow and deny lists

### DIFF
--- a/travis-ci/vmtest/run_selftests.sh
+++ b/travis-ci/vmtest/run_selftests.sh
@@ -74,6 +74,9 @@ ALLOWLIST=$(read_lists \
 	"$local_configs_path/ALLOWLIST.${ARCH}" \
 )
 
+echo "DENYLIST: ${DENYLIST}"
+echo "ALLOWLIST: ${ALLOWLIST}"
+
 cd ${PROJECT_NAME}/selftests/bpf
 
 test_progs


### PR DESCRIPTION
We should include the deny and allow lists used somewhere in the output
of our CI runs in order to improve debuggability in general. With this
change we print out these lists once assembled.

Signed-off-by: Daniel Müller <deso@posteo.net>