### PR TITLE
Explicitly specify Qemu image path to use

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,7 @@ jobs:
           project-name: 'libbpf'
           arch: ${{ matrix.arch }}
           kernel-root: '.'
+          image-output: '/tmp/root.img'
       - name: Run selftests
         uses: libbpf/ci/run-qemu@master
         with:


### PR DESCRIPTION
The path to the file system image used by our invocation of Qemu is
currently hard coded to /tmp/root.img somewhere in a different
repository. With
https://github.com/libbpf/ci/commit/da44c0b6ee29ec53776c1303f7ac790b7e337db5
landed we have the option of specifying it explicitly from here. Let's
do just that, so that we can remove the default value from libbpf/ci
altogether.

Signed-off-by: Daniel Müller <deso@posteo.net>