### PR TITLE
Support running of individual tests

### DIFF
--- a/travis-ci/vmtest/run_selftests.sh
+++ b/travis-ci/vmtest/run_selftests.sh
@@ -81,7 +81,13 @@ echo "ALLOWLIST: ${ALLOWLIST}"
 
 cd ${PROJECT_NAME}/selftests/bpf
 
-test_progs
-test_progs_noalu
-test_maps
-test_verifier
+if [ $# -eq 0 ]; then
+	test_progs
+	test_progs_noalu
+	test_maps
+	test_verifier
+else
+	for test_name in "$@"; do
+		"${test_name}"
+	done
+fi


### PR DESCRIPTION
This change adjusts the run_selftests.sh script to accept an optional
list of arguments specifying the tests to run. We will make use of it
once we run selftests in parallel.

Signed-off-by: Daniel Müller <deso@posteo.net>