### PR TITLE
Add lru_bug to s390x denylist

### DIFF
--- a/travis-ci/vmtest/configs/DENYLIST.s390x
+++ b/travis-ci/vmtest/configs/DENYLIST.s390x
@@ -1,1 +1,2 @@
 tc_redirect/tc_redirect_dtime            # very flaky
+lru_bug                                  # not yet in bpf-next denylist


### PR DESCRIPTION
This change adds the lru_bug to the s390x denylist. It was already added
to the upstream denylist of bpf, but not bpf-next. Pull request #123 [0]
added the original patch for bpf to the repository, but with recent
upstream changes to bpf-next, it stopped applying cleanly.

[0] https://github.com/kernel-patches/vmtest/pull/123

Signed-off-by: Daniel Müller <deso@posteo.net>