### PR TITLE
Run selftests as part of a separate job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,6 @@ name: bpf-ci
 on:
   pull_request:
 
-concurrency: 
-  group: ci-test-${{ github.head_ref }}
-  cancel-in-progress: true
-
 jobs:
   llvm-toolchain:
     runs-on: ubuntu-latest
@@ -14,7 +10,7 @@ jobs:
       llvm: ${{ steps.llvm-toolchain-impl.outputs.version }}
     steps:
       - id: llvm-version
-        uses: libbpf/ci/get-llvm-version@master
+        uses: danielocfb/libbpf-ci/get-llvm-version@topic/ci
       - id: llvm-toolchain-impl
         shell: bash
         run: echo "::set-output name=version::llvm-${{ steps.llvm-version.outputs.version }}"
@@ -44,10 +40,10 @@ jobs:
       REPO_ROOT: ${{ github.workspace }}
       REPO_PATH: ""
     steps:
-      - uses: actions/checkout@v2
+      - uses: danielocfb/checkout@main
       - if: ${{ github.repository == 'kernel-patches/vmtest' }}
         name: Download bpf-next tree
-        uses: libbpf/ci/get-linux-source@master
+        uses: danielocfb/libbpf-ci/get-linux-source@topic/ci
         with:
           dest: '.kernel'
       - if: ${{ github.repository == 'kernel-patches/vmtest' }}
@@ -57,24 +53,24 @@ jobs:
           rm -rf .kernel/.git
           cp -rf .kernel/. .
           rm -rf .kernel
-      - uses: libbpf/ci/patch-kernel@master
+      - uses: danielocfb/libbpf-ci/patch-kernel@topic/ci
         with:
           patches-root: '${{ github.workspace }}/travis-ci/diffs'
           repo-root: '${{ github.workspace }}'
       - name: Setup build environment
-        uses: libbpf/ci/setup-build-env@master
+        uses: danielocfb/libbpf-ci/setup-build-env@topic/ci
       - name: Build kernel image
-        uses: libbpf/ci/build-linux@master
+        uses: danielocfb/libbpf-ci/build-linux@topic/ci
         with:
           arch: ${{ matrix.arch }}
           toolchain: ${{ matrix.toolchain }}
       - name: Build selftests
-        uses: libbpf/ci/build-selftests@master
+        uses: danielocfb/libbpf-ci/build-selftests@topic/ci
         with:
           vmlinux_btf: ${{ github.workspace }}/vmlinux
           toolchain: ${{ matrix.toolchain }}
       - name: Build samples
-        uses: libbpf/ci/build-samples@master
+        uses: danielocfb/libbpf-ci/build-samples@topic/ci
         with:
           vmlinux_btf: ${{ github.workspace }}/vmlinux
           toolchain: ${{ matrix.toolchain }}
@@ -114,14 +110,14 @@ jobs:
       - name: Untar artifacts
         run: tar -xzf vmlinux-${{ matrix.arch }}-${{ matrix.toolchain }}.tar.gz
       - name: Prepare rootfs
-        uses: libbpf/ci/prepare-rootfs@master
+        uses: danielocfb/libbpf-ci/prepare-rootfs@topic/ci
         with:
           project-name: 'libbpf'
           arch: ${{ matrix.arch }}
           kernel-root: '.'
           image-output: '/tmp/root.img'
       - name: Run selftests
-        uses: libbpf/ci/run-qemu@master
+        uses: danielocfb/libbpf-ci/run-qemu@topic/ci
         with:
           arch: ${{ matrix.arch}}
           img: '/tmp/root.img'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,11 +76,17 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
       - name: Tar artifacts
         run: |
+          file_list=""
+          if [ ${{ github.repository }} == 'kernel-patches/vmtest' ]; then
+            file_list="$(find . -iname Makefile | xargs) scripts/";
+          fi
+
           tar -czf vmlinux-${{ matrix.arch }}-${{ matrix.toolchain }}.tar.gz \
             .config \
             arch/*/boot/bzImage \
             include/config/auto.conf \
             include/generated/autoconf.h \
+            ${file_list} \
             --exclude '*.h' \
             --exclude '*.c' \
             selftests/bpf/ \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
             {\"kernel\": \"LATEST\", \"runs_on\": [\"ubuntu-latest\", \"self-hosted\"], \"arch\": \"x86_64\", \"toolchain\": \"${{ needs.llvm-toolchain.outputs.llvm }}\"}, \
             {\"kernel\": \"LATEST\", \"runs_on\": [\"z15\", \"self-hosted\"], \"arch\": \"s390x\", \"toolchain\": \"gcc\"} \
           ]}"
-  VM_Test:
+  build:
     needs: set-matrix
     runs-on: ${{ matrix.runs_on }}
     name: Kernel ${{ matrix.kernel }} on ${{ matrix.runs_on[0] }} with ${{ matrix.toolchain }}
@@ -78,6 +78,41 @@ jobs:
         with:
           vmlinux_btf: ${{ github.workspace }}/vmlinux
           toolchain: ${{ matrix.toolchain }}
+      - name: Tar artifacts
+        run: |
+          tar -czf vmlinux-${{ matrix.arch }}-${{ matrix.toolchain }}.tar.gz \
+            .config \
+            arch/*/boot/bzImage \
+            include/config/auto.conf \
+            include/generated/autoconf.h \
+            --exclude '*.h' \
+            --exclude '*.c' \
+            selftests/bpf/ \
+            vmlinux
+      - uses: actions/upload-artifact@v3
+        with:
+          name: vmlinux-${{ matrix.arch }}-${{ matrix.toolchain }}
+          if-no-files-found: error
+          path: vmlinux-${{ matrix.arch }}-${{ matrix.toolchain }}.tar.gz
+  test:
+    needs: [set-matrix, build]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.set-matrix.outputs.matrix) }}
+    runs-on: ${{ matrix.runs_on }}
+    timeout-minutes: 100
+    env:
+      KERNEL: ${{ matrix.kernel }}
+      REPO_ROOT: ${{ github.workspace }}
+      REPO_PATH: ""
+    steps:
+      - uses: actions/checkout@main
+      - uses: actions/download-artifact@v3
+        with:
+          name: vmlinux-${{ matrix.arch }}-${{ matrix.toolchain }}
+          path: .
+      - name: Untar artifacts
+        run: tar -xzf vmlinux-${{ matrix.arch }}-${{ matrix.toolchain }}.tar.gz
       - name: Prepare rootfs
         uses: libbpf/ci/prepare-rootfs@master
         with:


### PR DESCRIPTION
This change factors out the running of selftests into a separate job.
Doing so is a precursor to being able to running individual tests in
parallel, which in turn should decrease total CI run time and increase
resiliency to kernel panics encountered in one run.
To make that possible we basically have to have well defined output of
the build step that can be consumed by the test step. At this point,
this only means preserving kernel configuration, the selftests/bpf
folder contents, and the vmlinux image itself, and making them available
to tests. As such, we package them up as artifacts. We manually tar
those in order to preserve permissions [0] but also to potentially curb
any spurious 429 HTTP errors ("too many requests") caused by too many
individual files being uploaded if selftest/bpf folder contents grow
[1].
In its current form, we split the two stages after building the
selftests. An alternative split would be after generation of the Qemu
image. Based on arguably limited testing, the increase in artifact
upload and download size (almost doubling; presumably because of
additional files in the image) negates any speed ups achieved by
performing image generation as part of the build. It's also slightly
less natural, because bpftool tests are actually run as part of image
generation, and so part of the tests would be run in the build stage.

Note that because of GitHub Actions' limitations, scheduling of jobs
will not be optimal. Specifically, *any* test job is only eligible to
run once *all* build jobs have finished. Strictly speaking, the s390x
test job would only have to depend on the s390x build job, for example,
but that cannot be expressed in GitHub Actions -- at least not when
using job matrices. We could potentially fix that by "unfolding" the
matrix manually, but that quickly becomes cumbersome because GitHub
Actions does not support YAML Anchors either [2]. While that shortcoming
will have an impact on total CI run time, it should not have any bearing
on runner utilization (because the moment a job is finished the runner
can move on to serving another one). That increase will get mitigated
somewhat once we run tests in parallel.
Lastly, this patch also indirectly addresses the timeout issues
discussed earlier [3]. Specifically, because both the build and test
steps now have a 100 minute timeout, we are less likely to hit either,
even when executing on a slow runner.

[0] https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files
[1] https://github.com/actions/upload-artifact#too-many-uploads-resulting-in-429-responses
[2] https://github.com/actions/runner/issues/1182
[3] https://github.com/kernel-patches/vmtest/pull/103

Signed-off-by: Daniel Müller <deso@posteo.net>