### PR TITLE
Rename test_progs_noalu function to test_progs_no_alu32

### DIFF
--- a/travis-ci/vmtest/run_selftests.sh
+++ b/travis-ci/vmtest/run_selftests.sh
@@ -32,7 +32,7 @@ test_progs() {
   foldable end test_progs
 }
 
-test_progs_noalu() {
+test_progs_no_alu32() {
   foldable start test_progs-no_alu32 "Testing test_progs-no_alu32"
   ./test_progs-no_alu32 ${DENYLIST:+-d"$DENYLIST"} ${ALLOWLIST:+-a"$ALLOWLIST"} ${TEST_PROGS_ARGS} && true
   echo "test_progs-no_alu32:$?" >>"${STATUS_FILE}"
@@ -83,7 +83,7 @@ cd ${PROJECT_NAME}/selftests/bpf
 
 if [ $# -eq 0 ]; then
 	test_progs
-	test_progs_noalu
+	test_progs_no_alu32
 	test_maps
 	test_verifier
 else


### PR DESCRIPTION
As a follow up to 806b2eef533c ("Factor out test_progs_noalu function")
and taking into account feedback [0], this change renames the
test_progs_noalu function to test_progs_no_alu32, to stay closer to the
name of the binary being invoked.

[0] https://github.com/kernel-patches/vmtest/pull/124#discussion_r953175641

Signed-off-by: Daniel Müller <deso@posteo.net>