### PR TITLE
Only require self-hosted runners in kernel-patches organization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,16 @@ jobs:
             {"kernel": "LATEST", "runs_on": ["ubuntu-latest", "self-hosted"], "arch": "x86_64", "toolchain": "${{ needs.llvm-toolchain.outputs.llvm }}"},
             {"kernel": "LATEST", "runs_on": ["z15", "self-hosted"], "arch": "s390x", "toolchain": "gcc"},
           ]
+
+          if "${{ github.repository_owner }}" != "kernel-patches":
+            # Outside of kernel-patches, remove the self-hosted label and skip
+            # any testing on s390x, as no suitable runners will be available.
+            for idx in range(len(matrix) - 1, -1, -1):
+              if "z15" in matrix[idx]["runs_on"]:
+                del matrix[idx]
+              else:
+                matrix[idx]["runs_on"].remove("self-hosted")
+
           build_matrix = {"include": matrix}
           print(f"::set-output name=build_matrix::{dumps(build_matrix)}")
 


### PR DESCRIPTION
The kernel-patches organization hosts their own GitHub Actions runners
which generally are much quicker at running individual CI jobs. To that
end, aecee1ab23bf ("Run on self-hosted runners") prevented the running
on GitHub-hosted ones altogether.
We would still provide the possibility for users of the BPF CI system to
trigger runs without having to create a pull request against a
repository in said org [0] (which, in the future, could conceivably require
approval before executing actions).
To enable this use case, this change requires the self-hosted tag for
build and selftest jobs only when running inside the kernel-patches
organization.
Furthermore, because GitHub does not have any s390x runners, do not test
on these when outside of kernel-patches organization.

[0] https://github.com/kernel-patches/vmtest/pull/103

Signed-off-by: Daniel Müller <deso@posteo.net>