### PR TITLE
Explicitly provide kernel version to use

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,6 +152,7 @@ jobs:
         with:
           project-name: 'libbpf'
           arch: ${{ matrix.arch }}
+          kernel: ${{ matrix.kernel }}
           kernel-root: '.'
           image-output: '/tmp/root.img'
           test: ${{ matrix.test }}


### PR DESCRIPTION
We currently implicitly rely on the default value for the kernel version
of the prepare-rootfs action. That's counter intuitive, because we
explicitly carry around the kernel version to use in our job matrix.
Let's make the specification explicit instead.

Signed-off-by: Daniel Müller <deso@posteo.net>