### PR TITLE
Provide kernel-root argument to run-qemu action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,3 +162,4 @@ jobs:
           arch: ${{ matrix.arch}}
           img: '/tmp/root.img'
           vmlinuz: '${{ github.workspace }}/vmlinuz'
+          kernel-root: '.'


### PR DESCRIPTION
With https://github.com/libbpf/ci/pull/36 merged the run-qemu action now
accepts an additional argument, `kernel-root`.
Provide it to the action with the value appropriate for this repository.

Signed-off-by: Daniel Müller <deso@posteo.net>