### PR TITLE
[runners] Only pick up self-hosted runners on a handful or repos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,9 +35,14 @@ jobs:
             {"kernel": "LATEST", "runs_on": ["ubuntu-latest", "self-hosted"], "arch": "x86_64", "toolchain": "${{ needs.llvm-toolchain.outputs.llvm }}"},
             {"kernel": "LATEST", "runs_on": ["z15", "self-hosted"], "arch": "s390x", "toolchain": "gcc"},
           ]
+          self_hosted_repos = [
+            "kernel-patches/bpf",
+            "kernel-patches/vmtest",
+          ]
 
-          if "${{ github.repository_owner }}" != "kernel-patches":
-            # Outside of kernel-patches, remove the self-hosted label and skip
+          # Only a few repository within "kernel-patches" use self-hosted runners.
+          if "${{ github.repository_owner }}" != "kernel-patches" or "${{ github.repository }}" not in self_hosted_repos:
+            # Outside of those repositories, remove the self-hosted label and skip
             # any testing on s390x, as no suitable runners will be available.
             for idx in range(len(matrix) - 1, -1, -1):
               if "z15" in matrix[idx]["runs_on"]:


### PR DESCRIPTION
Not all repositories within the "kernel-patches" organization are using self-hosted runner. For instance, "bpf-rc" repo is not, "rcu-rc" is not. "rcu" may in the future.
This change only enables self-hosted on a selected list of repositories within a "kernel-patches".