### PR TITLE
[artifacts] Use zstd to compress artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,8 +117,8 @@ jobs:
               tools/include/ \
               tools/bpf/bpftool/";
           fi
-
-          tar -czf vmlinux-${{ matrix.arch }}-${{ matrix.toolchain }}.tar.gz \
+          # zstd is installed by default in the runner images.
+          tar -cf - \
             .config \
             arch/*/boot/bzImage \
             include/config/auto.conf \
@@ -126,12 +126,12 @@ jobs:
             ${file_list} \
             --exclude '*.h' \
             selftests/bpf/ \
-            vmlinux
+            vmlinux | zstd -T0 -19 -o vmlinux-${{ matrix.arch }}-${{ matrix.toolchain }}.tar.zst
       - uses: actions/upload-artifact@v3
         with:
           name: vmlinux-${{ matrix.arch }}-${{ matrix.toolchain }}
           if-no-files-found: error
-          path: vmlinux-${{ matrix.arch }}-${{ matrix.toolchain }}.tar.gz
+          path: vmlinux-${{ matrix.arch }}-${{ matrix.toolchain }}.tar.zst
   test:
     name: ${{ matrix.test }} on ${{ matrix.arch }} with ${{ matrix.toolchain }}
     needs: [set-matrix, build]
@@ -151,7 +151,8 @@ jobs:
           name: vmlinux-${{ matrix.arch }}-${{ matrix.toolchain }}
           path: .
       - name: Untar artifacts
-        run: tar -xzf vmlinux-${{ matrix.arch }}-${{ matrix.toolchain }}.tar.gz
+        # zstd is installed by default in the runner images.
+        run: zstd -d -T0  vmlinux-${{ matrix.arch }}-${{ matrix.toolchain }}.tar.zst --stdout | tar -xf -
       - name: Prepare rootfs
         uses: libbpf/ci/prepare-rootfs@master
         with:


### PR DESCRIPTION
zstd offers better compression ration and is multi-threaded so it can leverage the CPUs available in the host to compress/decompress faster. With better compression ratio, the size of the artifacts  uploaded/downloaded will be smaller hence faster upload/download.