### PR TITLE
Add deny_namespace to DENYLIST.s390x configuration

### DIFF
--- a/ci/vmtest/configs/DENYLIST.s390x
+++ b/ci/vmtest/configs/DENYLIST.s390x
@@ -1,3 +1,4 @@
+deny_namespace                           # not yet in bpf denylist
 tc_redirect/tc_redirect_dtime            # very flaky
 lru_bug                                  # not yet in bpf-next denylist
 usdt/basic                               # failing verifier due to bounds check after LLVM update


### PR DESCRIPTION
The deny_namespace selftest was recently added to validate the userns_create LSM hooks. The test does not work on s390x because LSM uses BPF trampoline.
8206e4e95230 ("selftests/bpf: Add selftest deny_namespace to s390x deny list") was added to the bpf-next tree, but the bpf CI runs are still failing because the commit is not in that tree. So as to avoid merge conflicts, let's just blacklist it on vmtest.

Signed-off-by: David Vernet <void@manifault.com>