### PR TITLE
update actions/checkout to v3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
       REPO_ROOT: ${{ github.workspace }}
       REPO_PATH: ""
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - if: ${{ github.repository == 'kernel-patches/vmtest' }}
         name: Download bpf-next tree
         uses: libbpf/ci/get-linux-source@master
@@ -145,7 +145,7 @@ jobs:
       REPO_ROOT: ${{ github.workspace }}
       REPO_PATH: ""
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
           name: vmlinux-${{ matrix.arch }}-${{ matrix.toolchain }}


### PR DESCRIPTION
Actions runs started showing the error:

> build for x86_64 with llvm-16
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout

This change sets actions/checkout to v3, which is an upgrade from v2 in out first use case, and a pinning to v3 vs main for the second use case.

Signed-off-by: Manu Bretelle <chantr4@gmail.com>