### PR TITLE
denylist: remove verify_pkcs7_sig from DENYLIST

### DIFF
--- a/ci/vmtest/configs/DENYLIST
+++ b/ci/vmtest/configs/DENYLIST
@@ -4,4 +4,3 @@ kprobe_multi_test/bench_attach
 core_reloc/enum64val
 core_reloc/size___diff_sz
 core_reloc/type_based___diff_sz
-verify_pkcs7_sig


### PR DESCRIPTION
This was fixed as part of libbpf/ci#52

Signed-off-by: Manu Bretelle <chantr4@gmail.com>