### PR TITLE
Run shellcheck only in vmtest repository

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   shellcheck:
+    # This workflow gets injected into other Linux repositories, but we don't
+    # want it to run there.
+    if: ${{ github.repository == 'kernel-patches/vmtest' }}
     name: ShellCheck
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Our vmtest repository files (including GitHub Actions workflow definitions) get injected into the Linux source code repository in order to trigger CI runs on it. As a result, any workflows defined here will run there as well. That is fine for our actual Linux tests, but not so for the linting of shell scripts: the linter was intended to only cover vmtest shell scripts itself.
Make linting conditional on the repository we are run in to prevent spurious invocations.

Signed-off-by: Daniel Müller <deso@posteo.net>