### PR TITLE
Gracefully fail parallel tests getting stuck

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,24 @@ jobs:
             with open(os.getenv("GITHUB_OUTPUT"), "a") as f:
               f.write(f"{name}={value}\n")
 
+          def generate_test_config(test):
+            """Create the configuration for the provided test."""
+            config = {
+              "test": test,
+              "continue_on_error": test.endswith("_parallel"),
+            }
+
+            # While in experimental mode, parallel jobs may get stuck anywhere,
+            # including in user space where the kernel won't detect a problem
+            # and panic. We add a second layer of (smaller) timeouts here such
+            # that if we get stuck in a parallel run, we hit this timeout and
+            # fail without affecting the overall job success (as would be the
+            # case if we hit the job-wide timeout).
+            if test.endswith("_parallel"):
+              config = {**config, "timeout-minutes": 30}
+
+            return config
+
           matrix = [
             {"kernel": "LATEST", "runs_on": ["ubuntu-latest", "self-hosted"], "arch": "x86_64", "toolchain": "gcc"},
             {"kernel": "LATEST", "runs_on": ["ubuntu-latest", "self-hosted"], "arch": "x86_64", "toolchain": "${{ needs.llvm-toolchain.outputs.llvm }}"},
@@ -67,7 +85,7 @@ jobs:
             "test_maps",
             "test_verifier",
           ]
-          test_matrix = {"include": [{**config, **{"test": test, "continue_on_error": test.endswith("_parallel")}}
+          test_matrix = {"include": [{**config, **generate_test_config(test)}
                                       for config in matrix
                                         for test in tests]}
           set_output("test_matrix", dumps(test_matrix))


### PR DESCRIPTION
We have seen cases where the new parallel tests get stuck and we hit the overall workload timeout (e.g., [0]). That is despite us having enabled various panic on {soft lockup, hard lockup, task hang} settings already. That can happen, for example, if test_progs itself (i.e., the user space portion) encounters a deadlock.
The test being marked as failed in such a case is causing some noise in Patchwork. To work around this issue, this change introduces a second level of timeouts, specifically for parallel job runs. Because these timeouts are now attached directly to the job, which in turn is marked as continue-on-error, they no longer cause failure of the overall workflow.

I have verified this behavior with the following GitHub Actions configuration, in which the "Test" step hit the 1 minute timeout but the overall job succeeded [1].

```yaml
jobs:
  test:
    runs-on: ubuntu-latest
    timeout-minutes: 3
    steps:
      - name: Test
        continue-on-error: true
        timeout-minutes: 1
        shell: bash
        run: sleep 120
```

[0] https://github.com/kernel-patches/vmtest/actions/runs/3371914924/jobs/5595049018
[1] https://github.com/danielocfb/all-things-test/actions/runs/3373709973/jobs/5598556394

Signed-off-by: Daniel Müller <deso@posteo.net>