### PR TITLE
diffs: fix bpf-next build failures

### DIFF
--- a/ci/diffs/0001-bpftool-Fix-NULL-pointer-dereference-when-pin-PROG-M.diff
+++ b/ci/diffs/0001-bpftool-Fix-NULL-pointer-dereference-when-pin-PROG-M.diff
@@ -1,0 +1,45 @@
+From 0dd340f3549863e1289a872057743c9a177d1e3f Mon Sep 17 00:00:00 2001
+From: Pu Lehui <pulehui@huawei.com>
+Date: Wed, 2 Nov 2022 16:40:34 +0800
+Subject: [PATCH 1/2] bpftool: Fix NULL pointer dereference when pin {PROG,
+ MAP, LINK} without FILE
+
+When using bpftool to pin {PROG, MAP, LINK} without FILE,
+segmentation fault will occur. The reson is that the lack
+of FILE will cause strlen to trigger NULL pointer dereference.
+The corresponding stacktrace is shown below:
+
+do_pin
+  do_pin_any
+    do_pin_fd
+      mount_bpffs_for_pin
+        strlen(name) <- NULL pointer dereference
+
+Fix it by adding validation to the common process.
+
+Fixes: 75a1e792c335 ("tools: bpftool: Allow all prog/map handles for pinning objects")
+Signed-off-by: Pu Lehui <pulehui@huawei.com>
+Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>
+Reviewed-by: Quentin Monnet <quentin@isovalent.com>
+Link: https://lore.kernel.org/bpf/20221102084034.3342995-1-pulehui@huaweicloud.com
+---
+ tools/bpf/bpftool/common.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/tools/bpf/bpftool/common.c b/tools/bpf/bpftool/common.c
+index e4d33bc8bbbf..653c130a0aaa 100644
+--- a/tools/bpf/bpftool/common.c
++++ b/tools/bpf/bpftool/common.c
+@@ -302,6 +302,9 @@ int do_pin_any(int argc, char **argv, int (*get_fd)(int *, char ***))
+ 	int err;
+ 	int fd;
+ 
++	if (!REQ_ARGS(3))
++		return -EINVAL;
++
+ 	fd = get_fd(&argc, &argv);
+ 	if (fd < 0)
+ 		return fd;
+-- 
+2.30.2
+

--- a/ci/diffs/0002-tools-headers-uapi-pull-in-stddef.h-to-fix-BPF-selft.diff
+++ b/ci/diffs/0002-tools-headers-uapi-pull-in-stddef.h-to-fix-BPF-selft.diff
@@ -1,0 +1,104 @@
+From 038fafe1d1c92b8488e5e71ebea819050219dd6f Mon Sep 17 00:00:00 2001
+From: Andrii Nakryiko <andrii@kernel.org>
+Date: Wed, 2 Nov 2022 11:04:17 -0700
+Subject: [PATCH 2/2] tools headers uapi: pull in stddef.h to fix BPF selftests
+ build in CI
+
+With recent sync of linux/in.h tools/include headers are now relying on
+__DECLARE_FLEX_ARRAY macro, which isn't itself defined inside
+tools/include headers anywhere and is instead assumed to be present in
+system-wide UAPI header. This breaks isolated environments that don't
+have kernel UAPI headers installed system-wide, like BPF CI ([0]).
+
+To fix this, bring in include/uapi/linux/stddef.h into tools/include. We
+can't just copy/paste it, though, it has to be processed with
+scripts/headers_install.sh, which has a dependency on scripts/unifdef.
+So the full command to (re-)generate stddef.h for inclusion into
+tools/include directory is:
+
+  $ make scripts_unifdef && \
+    cp $KBUILD_OUTPUT/scripts/unifdef scripts/ && \
+    scripts/headers_install.sh include/uapi/linux/stddef.h tools/include/uapi/linux/stddef.h
+
+This assumes KBUILD_OUTPUT envvar is set and used for out-of-tree builds.
+
+  [0] https://github.com/kernel-patches/bpf/actions/runs/3379432493/jobs/5610982609
+
+Cc: Jakub Kicinski <kuba@kernel.org>
+Cc: Arnaldo Carvalho de Melo <acme@redhat.com>
+Fixes: 036b8f5b8970 ("tools headers uapi: Update linux/in.h copy")
+Signed-off-by: Andrii Nakryiko <andrii@kernel.org>
+---
+ tools/include/uapi/linux/in.h     |  1 +
+ tools/include/uapi/linux/stddef.h | 47 +++++++++++++++++++++++++++++++
+ 2 files changed, 48 insertions(+)
+ create mode 100644 tools/include/uapi/linux/stddef.h
+
+diff --git a/tools/include/uapi/linux/in.h b/tools/include/uapi/linux/in.h
+index f243ce665f74..07a4cb149305 100644
+--- a/tools/include/uapi/linux/in.h
++++ b/tools/include/uapi/linux/in.h
+@@ -20,6 +20,7 @@
+ #define _UAPI_LINUX_IN_H
+ 
+ #include <linux/types.h>
++#include <linux/stddef.h>
+ #include <linux/libc-compat.h>
+ #include <linux/socket.h>
+ 
+diff --git a/tools/include/uapi/linux/stddef.h b/tools/include/uapi/linux/stddef.h
+new file mode 100644
+index 000000000000..bb6ea517efb5
+--- /dev/null
++++ b/tools/include/uapi/linux/stddef.h
+@@ -0,0 +1,47 @@
++/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
++#ifndef _LINUX_STDDEF_H
++#define _LINUX_STDDEF_H
++
++
++
++#ifndef __always_inline
++#define __always_inline __inline__
++#endif
++
++/**
++ * __struct_group() - Create a mirrored named and anonyomous struct
++ *
++ * @TAG: The tag name for the named sub-struct (usually empty)
++ * @NAME: The identifier name of the mirrored sub-struct
++ * @ATTRS: Any struct attributes (usually empty)
++ * @MEMBERS: The member declarations for the mirrored structs
++ *
++ * Used to create an anonymous union of two structs with identical layout
++ * and size: one anonymous and one named. The former's members can be used
++ * normally without sub-struct naming, and the latter can be used to
++ * reason about the start, end, and size of the group of struct members.
++ * The named struct can also be explicitly tagged for layer reuse, as well
++ * as both having struct attributes appended.
++ */
++#define __struct_group(TAG, NAME, ATTRS, MEMBERS...) \
++	union { \
++		struct { MEMBERS } ATTRS; \
++		struct TAG { MEMBERS } ATTRS NAME; \
++	}
++
++/**
++ * __DECLARE_FLEX_ARRAY() - Declare a flexible array usable in a union
++ *
++ * @TYPE: The type of each flexible array element
++ * @NAME: The name of the flexible array member
++ *
++ * In order to have a flexible array member in a union or alone in a
++ * struct, it needs to be wrapped in an anonymous struct with at least 1
++ * named member, but that member can be empty.
++ */
++#define __DECLARE_FLEX_ARRAY(TYPE, NAME)	\
++	struct { \
++		struct { } __empty_ ## NAME; \
++		TYPE NAME[]; \
++	}
++#endif
+-- 
+2.30.2
+


### PR DESCRIPTION
Temporarily backport [0] until proper fixes make it to bpf-next from bpf tree.

  [0] https://patchwork.kernel.org/project/netdevbpf/list/?series=691352&state=*

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>