### PR TITLE
Cache kernel build artifacts and perform incremental kernel builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: bpf-ci
 
 on:
   pull_request:
+  push:
+    branches:
+      - bpf_base
+      - bpf-next_base
 
 concurrency:
   group: ci-test-${{ github.head_ref }}
@@ -119,6 +123,10 @@ jobs:
       KBUILD_OUTPUT: kbuild-output/
     steps:
       - uses: actions/checkout@v3
+        # We fetch an actual bit of history here to facilitate incremental
+        # builds (which may check out some earlier upstream change).
+        with:
+          fetch-depth: 50
       - if: ${{ github.repository == 'kernel-patches/vmtest' }}
         name: Download bpf-next tree
         uses: libbpf/ci/get-linux-source@master
@@ -131,6 +139,70 @@ jobs:
           rm -rf .kernel/.git
           cp -rf .kernel/. .
           rm -rf .kernel
+      - name: Get commit meta-data
+        id: get-commit-metadata
+        shell: bash
+        run: |
+          echo "timestamp=$(git show --format='%ct' --no-patch)" >> "${GITHUB_OUTPUT}"
+      - name: Pull recent KBUILD_OUTPUT contents
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.KBUILD_OUTPUT }}
+          key: kbuild-output-${{ runner.os }}-${{ matrix.toolchain }}-${{ steps.get-commit-metadata.outputs.timestamp }}-${{ github.sha }}
+          restore-keys: |
+            kbuild-output-${{ runner.os }}-${{ matrix.toolchain }}-${{ steps.get-commit-metadata.outputs.timestamp }}-
+            kbuild-output-${{ runner.os }}-${{ matrix.toolchain }}-
+      - name: Prepare incremental build
+        shell: bash
+        run: |
+          set -e -u
+
+          # $1 - the SHA-1 to fetch and check out
+          fetch_and_checkout() {
+            local build_base_sha="${1}"
+
+            # If cached artifacts became stale for one reason or another, we
+            # may not have the build base SHA available. Fetch it and retry.
+            git fetch origin "${build_base_sha}" && git checkout --quiet "${build_base_sha}"
+          }
+
+          # $1 - value of KBUILD_OUTPUT
+          clear_cache_artifacts() {
+            local kbuild_output="${1}"
+            echo "Unable to find earlier upstream ref. Discarding KBUILD_OUTPUT contents..."
+            rm --recursive --force "${kbuild_output}"
+            mkdir "${kbuild_output}"
+            false
+          }
+
+          # $1 - build time stamp
+          restore_source_code_times() {
+            local build_timestamp="${1}"
+            git ls-files | xargs --max-args=10000 touch -m --no-create --date="${build_timestamp}"
+            git checkout --quiet -
+            echo "Restored source code time stamp to time of last build"
+          }
+
+          mkdir --parents "${KBUILD_OUTPUT}"
+          build_base_sha="${{ github.sha }}"
+          echo "Using build base SHA-1 ${build_base_sha}"
+
+          if [ -f "${KBUILD_OUTPUT}/.build-base-sha" -a -f "${KBUILD_OUTPUT}/.build-timestamp" ]; then
+            build_base_sha="$(cat "${KBUILD_OUTPUT}/.build-base-sha")"
+            build_timestamp="$(cat "${KBUILD_OUTPUT}/.build-timestamp")"
+            echo "Setting up build state for ${build_base_sha} @ ${build_timestamp}"
+
+            (
+              git checkout --quiet "${build_base_sha}" \
+                || fetch_and_checkout "${build_base_sha}" \
+                || clear_cache_artifacts "${KBUILD_OUTPUT}"
+            ) && restore_source_code_times "${build_timestamp}"
+          else
+            echo "No previous build data found"
+          fi
+
+          echo -n "${build_base_sha}" > "${KBUILD_OUTPUT}/.build-base-sha"
+          echo -n "$(date --iso-8601=ns)" > "${KBUILD_OUTPUT}/.build-timestamp"
       - uses: libbpf/ci/patch-kernel@master
         with:
           patches-root: '${{ github.workspace }}/ci/diffs'
@@ -178,12 +250,21 @@ jobs:
             ${file_list} \
             --exclude '*.h' \
             selftests/bpf/ | zstd -T0 -19 -o vmlinux-${{ matrix.arch }}-${{ matrix.toolchain }}.tar.zst
+      - if: ${{ github.event_name != 'push' }}
+        name: Remove KBUILD_OUTPUT contents
+        shell: bash
+        run: |
+          # Remove $KBUILD_OUTPUT to prevent cache creation for pull requests.
+          # Only on pushed changes are build artifacts actually cached, because
+          # of github.com/actions/cache's cache isolation logic.
+          rm -rf "${KBUILD_OUTPUT}"
       - uses: actions/upload-artifact@v3
         with:
           name: vmlinux-${{ matrix.arch }}-${{ matrix.toolchain }}
           if-no-files-found: error
           path: vmlinux-${{ matrix.arch }}-${{ matrix.toolchain }}.tar.zst
   test:
+    if: ${{ github.event_name != 'push' }}
     name: ${{ matrix.test }} on ${{ matrix.arch }} with ${{ matrix.toolchain }}
     needs: [set-matrix, build]
     strategy:


### PR DESCRIPTION
This change introduces the means for performing incremental kernel builds in CI in order to decrease overall CI turn-around times. We piggy back (and rely) on the kernel's own make-based build infrastructure for that purpose. Specifically, with https://github.com/libbpf/ci/pull/67 we have set the stage for separating build artifacts from source code. With the change at hand we use this capability in conjunction with the `actions/cache` [0] GitHub Actions action to share intermediate build artifacts between CI runs, enabling the kernel build to only rebuild what has changed, as opposed to everything unconditionally.

There are several wrinkles to doing so. The first one is that GitHub Actions checks out the source code anew every time a workflow is run. Because git does not store file meta data like time stamps, but the kernel's build system relies solely on last-modified time stamps, we need a way to approximate the source code time stamps from the previous build. The way we do that is by first remembering both the time stamp and the SHA-1 at which we built and carry that over to subsequent builds. These subsequent builds then make sure to check out said SHA-1, adjust the last-modified time stamps of the entire tree, and then check out the code as it is meant to be tested by the very workflow run in question.

Second, `actions/cache` imposes several restrictions on cached artifacts: only artifacts produced on certain branches can actually be used (to achieve cache isolation) [1], there is a 10 GiB cache-artifact limit per repository [2], and the API is questionable. To circumvent the isolation-imposed requirements, we use the fact that we are maintaining a base branch against which pull requests are created to our advantage. Specifically, once this branch is updated (i.e., pushed to) we trigger a CI run which builds the kernel (already potentially incrementally) and then stores intermediate build artifacts. Pull requests created against this branch (i.e., every one created by Kernel Patches Daemon) will be able to use those artifacts.

Doing so indirectly also addresses the space constraints: the packed build artifacts are <1GiB in size. Because we only need to keep one set of artifacts for each arch and toolchain combo (currently: three) we don't need to worry about trashing (as a side note, these limitations don't seem to be enforced, certainly not rigorously or in a timely manner; I've had >34GiB of build artifacts cached for several hours without an eviction happening).

Because of the questionable API surface, we have to jump through hoops in order to prevent cache creation for regular pull requests: we remove the KBUILD_OUTPUT contents in a separate step, which causes no cache to be created.

As a result of this introduced infrastructure, we see a significant decrease of the "Build Kernel Image" step, which is part of every CI run (happening three times): on GitHub-hosted runners we get down from somewhere in the vicinity of 20minutes to <2minutes. Note that these results depend on what changes the patches in a series make: if a patch modifies a header included by each .c file then the result will be close to a full rebuild irrespective of this infrastructure. Conversely, if a patch only updates documentation the incremental rebuild can be close to instant. In practice, based on a weekend's worth of observations, we seem to be ending up close to "doing almost nothing" almost all the time than to doing a full rebuild.

Note that incremental builds are not bullet proof and to a somewhat large degree we are at the mercy of them working correctly. However, when we encounter a build failure we first attempt a 'make clean' followed by a full rebuild [4]. This is expected to solve build related problems in all conceivable cases. There is, however, the chance of miscompilation or similar issues introduced as part of buggy incremental recompilation logic. A brief survey within Meta's kernel group suggests that generally developers rely on incremental builds and anecdotal problems were always in the "build fails" realm. #dogfood

Note furthermore that selftest and sample builds are not covered by the incremental build machinery. The main reason for that is that neither of them honors KBUILD_OUTPUT -- a deficiency known to upstream Linux folks but not yet addressed. We could work around that conceptually, but payoff is less for these steps and an upstream fix could get us there without added complexity in the CI itself.

Lastly, it is important to note that, should CI, despite all efforts to the contrary, get stuck because a cache somehow contains corrupted data causing us to fail builds, the GitHub UI allows for the deletion of cache artifacts. If no caches are present, this feature is basically a no-op from an initial build perspective (i.e., a full build will be performed).

[0] https://github.com/actions/cache
[1] https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
[2] https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy
[3] https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#deleting-cache-entries 
[4] https://github.com/libbpf/ci/pull/73

Signed-off-by: Daniel Müller <deso@posteo.net>