### PR TITLE
Use matrix.arch as cache key identifier

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,9 +148,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.KBUILD_OUTPUT }}
-          key: kbuild-output-${{ matrix.arch }}-${{ matrix.toolchain }}-${{ steps.get-commit-metadata.outputs.timestamp }}-${{ github.sha }}
+          key: kbuild-output-${{ matrix.arch }}-${{ matrix.toolchain }}-${{ github.ref_name}}-${{ steps.get-commit-metadata.outputs.timestamp }}-${{ github.sha }}
           restore-keys: |
-            kbuild-output-${{ matrix.arch }}-${{ matrix.toolchain }}-${{ steps.get-commit-metadata.outputs.timestamp }}-
+            kbuild-output-${{ matrix.arch }}-${{ matrix.toolchain }}-${{ github.ref_name}}-${{ steps.get-commit-metadata.outputs.timestamp }}-
+            kbuild-output-${{ matrix.arch }}-${{ matrix.toolchain }}-${{ github.ref_name}}-
             kbuild-output-${{ matrix.arch }}-${{ matrix.toolchain }}-
       - name: Prepare incremental build
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,10 +148,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.KBUILD_OUTPUT }}
-          key: kbuild-output-${{ runner.os }}-${{ matrix.toolchain }}-${{ steps.get-commit-metadata.outputs.timestamp }}-${{ github.sha }}
+          key: kbuild-output-${{ matrix.arch }}-${{ matrix.toolchain }}-${{ steps.get-commit-metadata.outputs.timestamp }}-${{ github.sha }}
           restore-keys: |
-            kbuild-output-${{ runner.os }}-${{ matrix.toolchain }}-${{ steps.get-commit-metadata.outputs.timestamp }}-
-            kbuild-output-${{ runner.os }}-${{ matrix.toolchain }}-
+            kbuild-output-${{ matrix.arch }}-${{ matrix.toolchain }}-${{ steps.get-commit-metadata.outputs.timestamp }}-
+            kbuild-output-${{ matrix.arch }}-${{ matrix.toolchain }}-
       - name: Prepare incremental build
         shell: bash
         run: |


### PR DESCRIPTION
We have seen some architecture related build failures with the incremental build logic in place. E.g.,
https://github.com/kernel-patches/bpf/actions/runs/3441158955/jobs/5740411241#step:10:49

We can see that we picked up the cache from
kbuild-output-Linux-gcc-1668121889-67377655e58ae24ef2125c05e4dcfeb2e59d64dc. That cache was actually created on x86_64, but the job is running aarch64.
The reason that is done is because we are using `runner.os` as part of the key, when really we should be using `matrix.arch`. Let's use the latter instead. We only currently have one OS we test on.

Signed-off-by: Daniel Müller <deso@posteo.net>