### PR TITLE
Use a different branch key depending on event received

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,14 +144,19 @@ jobs:
         shell: bash
         run: |
           echo "timestamp=$(git show --format='%ct' --no-patch)" >> "${GITHUB_OUTPUT}"
+          if [ ${{ github.event_name }} = 'push' ]; then
+            echo "branch=${{ github.ref_name }}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "branch=${{ github.base_ref }}" >> "${GITHUB_OUTPUT}"
+          fi
       - name: Pull recent KBUILD_OUTPUT contents
         uses: actions/cache@v3
         with:
           path: ${{ env.KBUILD_OUTPUT }}
-          key: kbuild-output-${{ matrix.arch }}-${{ matrix.toolchain }}-${{ github.ref_name}}-${{ steps.get-commit-metadata.outputs.timestamp }}-${{ github.sha }}
+          key: kbuild-output-${{ matrix.arch }}-${{ matrix.toolchain }}-${{ steps.get-commit-metadata.outputs.branch }}-${{ steps.get-commit-metadata.outputs.timestamp }}-${{ github.sha }}
           restore-keys: |
-            kbuild-output-${{ matrix.arch }}-${{ matrix.toolchain }}-${{ github.ref_name}}-${{ steps.get-commit-metadata.outputs.timestamp }}-
-            kbuild-output-${{ matrix.arch }}-${{ matrix.toolchain }}-${{ github.ref_name}}-
+            kbuild-output-${{ matrix.arch }}-${{ matrix.toolchain }}-${{ steps.get-commit-metadata.outputs.branch }}-${{ steps.get-commit-metadata.outputs.timestamp }}-
+            kbuild-output-${{ matrix.arch }}-${{ matrix.toolchain }}-${{ steps.get-commit-metadata.outputs.branch }}-
             kbuild-output-${{ matrix.arch }}-${{ matrix.toolchain }}-
       - name: Prepare incremental build
         shell: bash


### PR DESCRIPTION
With commit 0f78398f5f30 ("Include base branch name in cache key identifier") we still have one problem: GitHub uses different attributes to represent the various branches/refs of interest in different contexts. E.g., in pull requests it populates the `base_ref` field, whereas for pushes it is empty. Similarly, `ref_name` refers to different things.
With this change we "generate" the branch name to include in the cache key identifier with keeping that into account. Basically, when we want to create the cache (on the "push" path) we can rely on `ref_name`, whereas when we are interested in pulling the cache (pull request), we need to use `base_ref`.

Signed-off-by: Daniel Müller <deso@posteo.net>