### PR TITLE
Adjust concurrency group

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
       - bpf-next_base
 
 concurrency:
-  group: ci-test-${{ github.head_ref }}
+  group: ci-test-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
We are seeing bpf-next_base push CI runs being canceled by GitHub Actions, e.g., https://github.com/kernel-patches/bpf/actions/runs/3445955491

The reason seems to be that on a push event, the head_ref attribute of the GitHub context is empty. Hence, we will end up with identical group names for bpf and bpf-next runs and one of them gets canceled (in practice it's always bpf-next, because it seems to get scheduled after bpf).
To fix this issue, let's work with ref_name instead. This attribute is always set. It does not have the same contents as head_ref on a pull request, but it should preserve the property we care about: it is identical to runs on the same pull request but between different pull requests.

Signed-off-by: Daniel Müller <deso@posteo.net>