### PR TITLE
Use a more robust way of identifying the baseline upstream commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,16 +144,25 @@ jobs:
         shell: bash
         run: |
           if [ ${{ github.event_name }} = 'push' ]; then
-            echo "branch=${{ github.ref_name }}" >> "${GITHUB_OUTPUT}"
-            # Ignore top most commit which just adds CI files.
-            commit="$(git rev-parse HEAD^)"
+            branch="${{ github.ref_name }}"
+            echo "branch=${branch}" >> "${GITHUB_OUTPUT}"
           else
-            echo "branch=${{ github.base_ref }}" >> "${GITHUB_OUTPUT}"
-            # For pull requests we just use the current HEAD.
-            commit="$(git rev-parse ${{ github.sha }})"
+            branch="${{ github.base_ref }}"
+            echo "branch=${branch}" >> "${GITHUB_OUTPUT}"
           fi
+
+          upstream=$(echo "${branch}" | sed 's@_base$@@')
+          commit="$(
+            git rev-parse "origin/${upstream}" &> /dev/null \
+              || (
+                git fetch --quiet --prune --no-tags --depth=1 --no-recurse-submodules origin +refs/heads/${upstream}:refs/remotes/origin/${upstream} \
+                  && git rev-parse "origin/${upstream}"
+              )
+          )"
+
           echo "timestamp=$(TZ=utc git show --format='%cd' --no-patch --date=iso-strict-local ${commit})" >> "${GITHUB_OUTPUT}"
           echo "commit=${commit}" >> "${GITHUB_OUTPUT}"
+          echo "Most recent upstream commit is ${commit}"
       - name: Pull recent KBUILD_OUTPUT contents
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Commit 31605ba85acb ("Work more with upstream commit SHA-1") adjusted the commit SHA-1 that we use as the actual base commit for incremental builds but also as part of the cache key identifier. When earlier we referenced a temporary KPD-created commit, we now use an upstream commit that has meaning outside the specific repository being worked on.

However, the way we got this upstream commit was not particularly great, as it made an implicit assumption about KPD creating exactly a single commit on top of upstream (i.e., we inferred that HEAD^ was the first upstream commit).

This change makes upstream commit identification more robust, by removing this assumption. Specifically, we piggy back on the branch name (in case of push) or base branch (in case of pull request), and remove the _base suffix. Then we resolve said name to the actual SHA-1. We already assume specific branch names to run on (e.g., we only run CI runs for pushed to bpf_base and bpf-next_base), so this logic doesn't introduce any new assumptions.

The main downside of this approach is that we now have to do another git fetch (i.e., potentially slow network operation), because the base branch is unlikely to be present in the checkout (we only check out the target branch along with a tiny bit of history).

Signed-off-by: Daniel Müller <deso@posteo.net>