### PR TITLE
Carry fewer build artifacts between build and test stages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,6 +256,12 @@ jobs:
       - if: ${{ github.event_name != 'push' }}
         name: Tar artifacts
         run: |
+          # Remove intermediate object files that we have no use for. Ideally
+          # we'd just exclude them from tar below, but it does not provide
+          # options to express the precise constraints.
+          find selftests/ -name "*.o" -a ! -name "*.bpf.o" -print0 | \
+            xargs --null --max-args=10000 rm
+
           file_list=""
           if [ "${{ github.repository }}" == "kernel-patches/vmtest" ]; then
             # Package up a bunch of additional infrastructure to support running
@@ -274,7 +280,10 @@ jobs:
             "${KBUILD_OUTPUT}"/include/generated/autoconf.h \
             "${KBUILD_OUTPUT}"/vmlinux \
             ${file_list} \
+            --exclude '*.cmd' \
+            --exclude '*.d' \
             --exclude '*.h' \
+            --exclude '*.output' \
             selftests/bpf/ | zstd -T0 -19 -o vmlinux-${{ matrix.arch }}-${{ matrix.toolchain }}.tar.zst
       - if: ${{ github.event_name != 'push' }}
         name: Remove KBUILD_OUTPUT contents


### PR DESCRIPTION
Depending on which run we look at, the transfer of build artifacts between the build and test stages of the workflow is among the most expensive steps, where content is compressed multiple times, sent over the network, and later downloaded again over the network and decompressed.
As such, decreasing the number of build artifacts that we include in the transfer may have a large impact. To give two examples:
- On selfhosted (x86) runners [0] uploading artifacts is regularly the longest taking step in the build phase and taring them is not insignificant either.
- On GitHub hosted runners (and with incremental kernel builds) [1] taring artifacts is the single most expensive step and uploading them has a fair contribution as well.

This change minimizes the number of build artifacts we carry over between stages by excluding a bunch of unnecessary build meta data files as well as intermediate object files that are not consumed by any tests. The size of artifacts changed as follows:
```
  vmlinux-aarch64-gcc     148 MB -> 137 MB (-7.43%)
  vmlinux-aarch64-llvm-16 122 MB -> 112 MB (-8.19%)
  vmlinux-s390x-gcc       138 MB -> 127 MB (-7.97%)
  vmlinux-x86_64-gcc      193 MB -> 184 MB (-4.66%)
  vmlinux-x86_64-llvm-16  141 MB -> 132 MB (-6.38%)
```

[0] https://github.com/kernel-patches/bpf/actions/runs/3580625932/jobs/6022910125
[1] https://github.com/danielocfb/kernel-patches-bpf/actions/runs/3566820589/jobs/5993751102