### PR TITLE
selftests/bpf: Change the name kprobe_multi_test/bench_attach to kprobe_multi_bench_attach in DENYLIST.

### DIFF
--- a/ci/vmtest/configs/DENYLIST
+++ b/ci/vmtest/configs/DENYLIST
@@ -1,6 +1,6 @@
 # TEMPORARY
 btf_dump/btf_dump: syntax
-kprobe_multi_test/bench_attach
+kprobe_multi_bench_attach
 core_reloc/enum64val
 core_reloc/size___diff_sz
 core_reloc/type_based___diff_sz


### PR DESCRIPTION

Since the test case was renamed, the DENYLIST should also be updated.

Signed-off-by: Kui-Feng Lee <kuifeng@fb.com>