### PR TITLE
Strip debug information from vmlinux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -262,6 +262,11 @@ jobs:
           find selftests/ -name "*.o" -a ! -name "*.bpf.o" -print0 | \
             xargs --null --max-args=10000 rm
 
+          # Strip debug information, which is excessively large (consuming
+          # bandwidth) while not actually being used (the kernel does not use
+          # DWARF to symbolize stacktraces).
+          strip --strip-debug "${KBUILD_OUTPUT}"/vmlinux
+
           file_list=""
           if [ "${{ github.repository }}" == "kernel-patches/vmtest" ]; then
             # Package up a bunch of additional infrastructure to support running


### PR DESCRIPTION
Continuing on the low priority effort of investigating BPF CI runtime bottlenecks and speeding up runs, this change proposes stripping debug information from vmlinux. This information should not be necessary for BPF CI to function and is not expected to affect debugability negatively either.

The uncompressed artifacts are impacted as follows (only looked at x86 LLVM):
```
  kbuild-output/vmlinux   390 MB -> 71 MB (-81.79%)
```

The size of of the actually transferred compressed artifacts changed as follows:
```
  vmlinux-aarch64-gcc     138 MB -> 61.7 MB (-55.28%)
  vmlinux-aarch64-llvm-16 112 MB -> 61.7 MB (-44.91%)
  vmlinux-s390x-gcc       128 MB -> 60.5 MB (-52.73%)
  vmlinux-x86_64-gcc      185 MB -> 60.0 MB (-67.56%)
  vmlinux-x86_64-llvm-16  133 MB -> 59.0 MB (-55.63%)
```

That's based on test run:
- https://github.com/kernel-patches/bpf/actions/runs/3688555119

Compared to most recent baseline:
- https://github.com/kernel-patches/bpf/actions/runs/3679784883

Note that it is likely that we can do still more. Specifically, `bzImage`, which we *also* transfer between stages, can actually be used to recreate vmlinux, meaning we could potentially save another 70 MiB of uncompressed data (unless we loose essential information in the process, which we will have to check; in any event, doing so requires a bit more work and is out of the scope of this very change).

Signed-off-by: Daniel Müller <deso@posteo.net>