### PR TITLE
ci/aarch64: temporarily disable xdp_bonding/xdp_bonding_redirect_multi subtest

### DIFF
--- a/ci/vmtest/configs/DENYLIST.aarch64
+++ b/ci/vmtest/configs/DENYLIST.aarch64
@@ -1,3 +1,4 @@
 cgrp_local_storage                  # libbpf: prog 'update_cookie_tracing': failed to attach: ERROR: strerror_r(-524)=22
-usdt/multispec                      # usdt_300_bad_attach unexpected pointer: 0x558c63d8f0
 core_reloc_btfgen                   # run_core_reloc_tests:FAIL:run_btfgen unexpected error: 32512 (errno 22)
+usdt/multispec                      # usdt_300_bad_attach unexpected pointer: 0x558c63d8f0
+xdp_bonding/xdp_bonding_redirect_multi                     # very unstable on aarch64


### PR DESCRIPTION
It's very unstable and frequently fails.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>