### PR TITLE
ci/aarch64: temporarily disable xdp_bonding/xdp_bonding_activebackup

### DIFF
--- a/ci/vmtest/configs/DENYLIST.aarch64
+++ b/ci/vmtest/configs/DENYLIST.aarch64
@@ -1,4 +1,5 @@
 cgrp_local_storage                  # libbpf: prog 'update_cookie_tracing': failed to attach: ERROR: strerror_r(-524)=22
 core_reloc_btfgen                   # run_core_reloc_tests:FAIL:run_btfgen unexpected error: 32512 (errno 22)
 usdt/multispec                      # usdt_300_bad_attach unexpected pointer: 0x558c63d8f0
+xdp_bonding/xdp_bonding_activebackup                       # very unstable on aarch64
 xdp_bonding/xdp_bonding_redirect_multi                     # very unstable on aarch64


### PR DESCRIPTION
It fails frequently in CI on the bpf branch. Andrii already disabled the xdp_bonding/xdp_bonding_redirect_multi subtest in f6c52be043fa ("ci/aarch64: temporarily disable xdp_bonding/xdp_bonding_redirect_multi subtest"), so let's do the same for another failing subtest.

Signed-off-by: David Vernet <void@manifault.com>