### PR TITLE
ci/aarch64: temporarily disable entire xdp_bonding suite on aarch64

### DIFF
--- a/ci/vmtest/configs/DENYLIST.aarch64
+++ b/ci/vmtest/configs/DENYLIST.aarch64
@@ -1,5 +1,4 @@
 cgrp_local_storage                  # libbpf: prog 'update_cookie_tracing': failed to attach: ERROR: strerror_r(-524)=22
 core_reloc_btfgen                   # run_core_reloc_tests:FAIL:run_btfgen unexpected error: 32512 (errno 22)
 usdt/multispec                      # usdt_300_bad_attach unexpected pointer: 0x558c63d8f0
-xdp_bonding/xdp_bonding_activebackup                       # very unstable on aarch64
-xdp_bonding/xdp_bonding_redirect_multi                     # very unstable on aarch64
+xdp_bonding                         # whole test suite is very unstable on aarch64


### PR DESCRIPTION
We've been seeing frequent random failures of various testcases in the xdp_bonding suite on aarch64. A couple of other commits disabled specific testcases, but others are flakily failing as well. Let's just disable the whole suite until we investigate, as the tests aren't providing any value at the moment anyways if we're just disabling them when they fail.

Signed-off-by: David Vernet <void@manifault.com>