### PR TITLE
ci/s390: fix CI issue with s390 build

### DIFF
--- a/ci/diffs/0001-Revert-arch-fix-broken-BuildID-for-arm64-and-riscv.patch
+++ b/ci/diffs/0001-Revert-arch-fix-broken-BuildID-for-arm64-and-riscv.patch
@@ -1,0 +1,30 @@
+From cb50dac513235c6996b9d26f959886ba1d7be607 Mon Sep 17 00:00:00 2001
+From: Eduard Zingerman <eddyz87@gmail.com>
+Date: Fri, 6 Jan 2023 13:59:26 +0200
+Subject: [PATCH] Revert "arch: fix broken BuildID for arm64 and riscv"
+
+This reverts commit 99cb0d917ffa1ab628bb67364ca9b162c07699b1.
+---
+ include/asm-generic/vmlinux.lds.h | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/include/asm-generic/vmlinux.lds.h b/include/asm-generic/vmlinux.lds.h
+index 659bf3b31c91..a94219e9916f 100644
+--- a/include/asm-generic/vmlinux.lds.h
++++ b/include/asm-generic/vmlinux.lds.h
+@@ -891,12 +891,7 @@
+ #define PRINTK_INDEX
+ #endif
+ 
+-/*
+- * Discard .note.GNU-stack, which is emitted as PROGBITS by the compiler.
+- * Otherwise, the type of .notes section would become PROGBITS instead of NOTES.
+- */
+ #define NOTES								\
+-	/DISCARD/ : { *(.note.GNU-stack) }				\
+ 	.notes : AT(ADDR(.notes) - LOAD_OFFSET) {			\
+ 		BOUNDED_SECTION_BY(.note.*, _notes)			\
+ 	} NOTES_HEADERS							\
+-- 
+2.39.0
+


### PR DESCRIPTION
Fixes a temporary issue with CI on s390 caused by one of the upstream commits. All recent pull requests are failing because of the build issue on s390, e.g.:
- https://github.com/kernel-patches/bpf/actions/runs/3851652311
- https://github.com/kernel-patches/bpf/actions/runs/3851642638
- https://github.com/kernel-patches/bpf/actions/runs/3851641331

This LKML link discusses the issue:
https://lkml.org/lkml/2023/1/2/30

The suggestion is to revert commit
99cb0d917ffa1ab628bb67364ca9b162c07699b1 .

I did this for my pull request and it worked:
https://github.com/kernel-patches/bpf/pull/4299

Signed-off-by: Eduard Zingerman <eddyz87@gmail.com>