### PR TITLE
Temporarily disable testing on `s390x`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,6 @@ jobs:
             {"kernel": "LATEST", "runs_on": [], "arch": Arch.x86_64.value, "toolchain": "${{ needs.llvm-toolchain.outputs.llvm }}"},
             {"kernel": "LATEST", "runs_on": [], "arch": Arch.aarch64.value, "toolchain": "gcc"},
             {"kernel": "LATEST", "runs_on": [], "arch": Arch.aarch64.value, "toolchain": "${{ needs.llvm-toolchain.outputs.llvm }}"},
-            {"kernel": "LATEST", "runs_on": [], "arch": Arch.s390x.value, "toolchain": "gcc"},
           ]
           self_hosted_repos = [
             "kernel-patches/bpf",


### PR DESCRIPTION
The s390x workflow is currently broken, caused by what appears to be a versioning mismatch in the LLVM apt snapshot that we consume. That is causing all our CI runs to fail, e.g., here [0].

We have reported the issue upstream [1], but to unblock CI, this change disables testing on s390x until the issue is resolved.

I have scheduled a test run here [2].

[0] https://github.com/kernel-patches/bpf/actions/runs/3944711143 [1] https://github.com/llvm/llvm-project/issues/60128 [2] https://github.com/kernel-patches/bpf/actions/runs/3952315347/jobs/6767240843

Signed-off-by: Daniel Müller <deso@posteo.net>