### PR TITLE
Revert "Temporarily disable testing on s390x"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,7 @@ jobs:
             {"kernel": "LATEST", "runs_on": [], "arch": Arch.x86_64.value, "toolchain": "${{ needs.llvm-toolchain.outputs.llvm }}"},
             {"kernel": "LATEST", "runs_on": [], "arch": Arch.aarch64.value, "toolchain": "gcc"},
             {"kernel": "LATEST", "runs_on": [], "arch": Arch.aarch64.value, "toolchain": "${{ needs.llvm-toolchain.outputs.llvm }}"},
+            {"kernel": "LATEST", "runs_on": [], "arch": Arch.s390x.value, "toolchain": "gcc"},
           ]
           self_hosted_repos = [
             "kernel-patches/bpf",


### PR DESCRIPTION
It appears as if the LLVM snapshot breakage for s390x has been resolved upstream and we can build and test on this architecture again. This change reverts commit 89413fe98c40f497d7f3fc6435b702ab744a9a12.

Signed-off-by: Daniel Müller <deso@posteo.net>