### PR TITLE
denylist: Disable test_ima in CI

### DIFF
--- a/ci/vmtest/configs/DENYLIST
+++ b/ci/vmtest/configs/DENYLIST
@@ -4,3 +4,4 @@ kprobe_multi_bench_attach
 core_reloc/enum64val
 core_reloc/size___diff_sz
 core_reloc/type_based___diff_sz
+test_ima	# All of CI is broken on it following 6.3-rc1 merge


### PR DESCRIPTION
The test_ima suite is broken following the 6.3-rc1 merge due to [0]. Until it's fixed (currently being discussed upstream), we should disable it in CI so that runs are unblocked.

[0]: https://lore.kernel.org/all/Y7T1hEhIL5TEmLEN@google.com/