### PR TITLE
denylist: Disable fexit_bpf2bpf/func_replace_return_code test

### DIFF
--- a/ci/vmtest/configs/DENYLIST
+++ b/ci/vmtest/configs/DENYLIST
@@ -5,3 +5,4 @@ core_reloc/enum64val
 core_reloc/size___diff_sz
 core_reloc/type_based___diff_sz
 test_ima	# All of CI is broken on it following 6.3-rc1 merge
+fexit_bpf2bpf


### PR DESCRIPTION
The fexit_bpf2bpf/func_replace_return_code testcase seems to be failing on all architectures and compilers. Disable it for all of CI.