### PR TITLE
[workflow] Add a 'veristat' job

### DIFF
--- a/.github/scripts/veristat-compare.py
+++ b/.github/scripts/veristat-compare.py
@@ -1,0 +1,150 @@
+import sys
+import csv
+import os
+
+# File format:
+#
+# Columns:
+#  0. file_name
+#  1. prog_name
+#  2. verdict_base
+#  3. verdict_comp
+#  4. verdict_diff
+#  5. total_states_base
+#  6. total_states_comp
+#  7. total_states_diff
+#
+# Records sample:
+#  file-a,a,success,failure,MISMATCH,12,12,+0 (+0.00%)
+#  file-b,b,success,success,MATCH,67,67,+0 (+0.00%)
+
+TRESHOLD_PCT = 0
+
+HEADERS = ['file_name', 'prog_name', 'verdict_base', 'verdict_comp',
+           'verdict_diff', 'total_states_base', 'total_states_comp',
+           'total_states_diff']
+
+FILE        = 0
+PROG        = 1
+VERDICT_OLD = 2
+VERDICT_NEW = 3
+STATES_OLD  = 5
+STATES_NEW  = 6
+
+if len(sys.argv) == 2:
+    CSV_PATH = sys.argv[1]
+else:
+    print(f'Usage: {sys.argv[0]} <compare.csv>>')
+    sys.exit(1)
+
+if not os.path.exists(CSV_PATH):
+    print(f'# {CSV_PATH} does not exist, failing step')
+    sys.exit(1)
+
+def read_table(path):
+    with open(path, newline='') as file:
+        reader = csv.reader(file)
+        headers = next(reader)
+        if headers != HEADERS:
+            raise Exception(f'Unexpected table header for {path}: {headers}')
+        return list(reader)
+
+table = read_table(CSV_PATH)
+new_failures = False
+changes = False
+headers = ['File', 'Program', 'Verdict', 'States Diff (%)']
+html_table = [headers]
+text_table = [headers]
+
+def compute_diff(v):
+    old = int(v[STATES_OLD]) if v[STATES_OLD] != 'N/A' else 0
+    new = int(v[STATES_NEW]) if v[STATES_NEW] != 'N/A' else 0
+    if old == 0:
+        return 1
+    return (new - old) / old
+
+for v in table:
+    add = False
+    html_verdict = v[VERDICT_NEW]
+    text_verdict = v[VERDICT_NEW]
+    diff = compute_diff(v)
+
+    if v[VERDICT_OLD] != v[VERDICT_NEW]:
+        changes = True
+        add = True
+        html_verdict = f'{v[VERDICT_OLD]} &rarr; {v[VERDICT_NEW]}'
+        text_verdict = f'{v[VERDICT_OLD]} -> {v[VERDICT_NEW]}'
+        if v[VERDICT_NEW] == 'failure':
+            new_failures = True
+            html_verdict += ' :bangbang:'
+            text_verdict += ' (!!)'
+
+    if abs(diff * 100) > TRESHOLD_PCT:
+        changes = True
+        add = True
+
+    if not add:
+        continue
+
+    diff_txt = '{:+.1f} %'.format(diff * 100)
+    html_table.append([v[FILE], v[PROG], html_verdict, diff_txt])
+    text_table.append([v[FILE], v[PROG], text_verdict, diff_txt])
+
+def print_table(rows, fn):
+    column_widths = [0] * len(rows[0])
+    for row in rows:
+        for i, col in enumerate(row):
+            column_widths[i] = max(column_widths[i], len(col))
+
+    def print_row(row):
+        line = '|'
+        for width, col in zip(column_widths, row):
+            line += ' ' + col.ljust(width) + ' |'
+        fn(line)
+
+    rows_iter = iter(rows)
+    print_row(next(rows_iter))
+
+    underscores = '|'
+    for width in column_widths:
+        underscores += '-' * (width + 2) + '|'
+    fn(underscores)
+
+    for row in rows_iter:
+        print_row(row)
+
+if new_failures:
+    section_name = '# There are new veristat failures'
+elif changes:
+    section_name = '# There are changes in verification performance'
+else:
+    section_name = '# No changes in verification performance'
+
+# Print the step summary
+
+if summary_path := os.getenv('GITHUB_STEP_SUMMARY', None):
+    summary_file = open(summary_path, 'a')
+
+def print_summary(s = ''):
+    if summary_file:
+        summary_file.write(f'{s}\n')
+
+print_summary(section_name)
+print(section_name)
+
+if new_failures or changes:
+    print()
+    print_table(text_table, print)
+    print()
+
+    print_summary()
+    print_summary('<details>')
+    print_summary('<summary>Click to expand</summary>')
+    print_summary()
+    print_table(html_table, print_summary)
+    print_summary()
+    print_summary('</details>')
+
+if new_failures:
+    print('Failing step because of the new failures')
+    sys.exit(1)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
       - bpf_base
       - bpf-next_base
 
+env:
+  veristat_arch: x86_64
+  veristat_toolchain: gcc
+
 concurrency:
   group: ci-test-${{ github.ref_name }}
   cancel-in-progress: true
@@ -17,6 +21,7 @@ jobs:
     outputs:
       build-matrix: ${{ steps.set-matrix-impl.outputs.build_matrix }}
       test-matrix: ${{ steps.set-matrix-impl.outputs.test_matrix }}
+      veristat-runs-on: ${{ steps.set-matrix-impl.outputs.veristat_runs_on }}
     steps:
       - id: set-matrix-impl
         shell: python3 -I {0}
@@ -108,6 +113,12 @@ jobs:
                                       for test in get_tests(config)
                                     ]}
           set_output("test_matrix", dumps(test_matrix))
+
+          veristat_runs_on = next(x['runs_on']
+                                  for x in matrix
+                                  if x['arch'] == "${{env.veristat_arch}}" and
+                                     x['toolchain'] == "${{env.veristat_toolchain}}")
+          set_output("veristat_runs_on", veristat_runs_on)
   build:
     name: build for ${{ matrix.arch }} with ${{ matrix.toolchain_full }}
     needs: set-matrix
@@ -242,8 +253,7 @@ jobs:
           kbuild-output: ${{ env.KBUILD_OUTPUT }}
           max-make-jobs: 32
           llvm-version: ${{ matrix.llvm-version }}
-      - if: ${{ github.event_name != 'push' }}
-        name: Build selftests
+      - name: Build selftests
         uses: libbpf/ci/build-selftests@main
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -258,8 +268,7 @@ jobs:
           kbuild-output: ${{ env.KBUILD_OUTPUT }}
           max-make-jobs: 32
           llvm-version: ${{ matrix.llvm-version }}
-      - if: ${{ github.event_name != 'push' }}
-        name: Tar artifacts
+      - name: Tar artifacts
         run: |
           # Remove intermediate object files that we have no use for. Ideally
           # we'd just exclude them from tar below, but it does not provide
@@ -303,8 +312,7 @@ jobs:
           # Only on pushed changes are build artifacts actually cached, because
           # of github.com/actions/cache's cache isolation logic.
           rm -rf "${KBUILD_OUTPUT}"
-      - if: ${{ github.event_name != 'push' }}
-        uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v3
         with:
           name: vmlinux-${{ matrix.arch }}-${{ matrix.toolchain_full }}
           if-no-files-found: error
@@ -353,3 +361,89 @@ jobs:
           kernel-root: '.'
           max-cpu: 8
           kernel-test: ${{ matrix.test }}
+  veristat:
+    name: veristat
+    needs: [set-matrix, build]
+    runs-on: ${{ fromJSON(needs.set-matrix.outputs.veristat-runs-on) }}
+    timeout-minutes: 100
+    env:
+      KERNEL: LATEST
+      REPO_ROOT: ${{ github.workspace }}
+      REPO_PATH: ""
+      KBUILD_OUTPUT: kbuild-output/
+    steps:
+      - name: Setup environment variables
+        run: |
+            echo arch_and_tool=${{ env.veristat_arch }}-${{ env.veristat_toolchain }} > \
+              ${GITHUB_ENV}
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: vmlinux-${{ env.arch_and_tool }}
+          path: .
+      - name: Untar artifacts
+        # zstd is installed by default in the runner images.
+        run: zstd -d -T0  vmlinux-${{ env.arch_and_tool }}.tar.zst --stdout | tar -xf -
+
+      - name: Prepare rootfs
+        uses: libbpf/ci/prepare-rootfs@main
+        with:
+          project-name: 'libbpf'
+          arch: x86_64
+          kernel: LATEST
+          kernel-root: '.'
+          kbuild-output: ${{ env.KBUILD_OUTPUT }}
+          image-output: '/tmp/root.img'
+          test: run_veristat
+
+      - name: Run veristat
+        uses: libbpf/ci/run-qemu@main
+        timeout-minutes: 10
+        with:
+          arch: x86_64
+          img: '/tmp/root.img'
+          vmlinuz: '${{ github.workspace }}/vmlinuz'
+          kernel-root: '.'
+          max-cpu: 8
+          kernel-test: run_veristat
+          output-dir: '${{ github.workspace }}'
+
+      # veristat.csv is produced by run-qemu run_veristat action
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.arch_and_tool }}-veristat-log
+          if-no-files-found: error
+          path: '${{ github.workspace }}/veristat.csv'
+
+      # For pull request:
+      # - get baseline log from cache
+      # - compare it to current run
+      - if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/cache/restore@v3
+        with:
+          key: ${{ env.arch_and_tool }}-veristat-baseline
+          restore-keys: |
+            ${{ env.arch_and_tool }}-veristat-baseline-
+          path: '${{ github.workspace }}/veristat-baseline.csv'
+
+      - if: ${{ github.event_name == 'pull_request' }}
+        name: Show veristat comparison
+        run: |
+          cd ${{ github.workspace }}
+          selftests/bpf/veristat \
+            --output-format csv \
+            --emit file,prog,verdict,states \
+            --compare veristat-baseline.csv veristat.csv > compare.csv
+          python3 ./.github/scripts/veristat-compare.py compare.csv
+
+      # For push: just put baseline log to cache
+      - if: ${{ github.event_name == 'push' }}
+        run: |
+          mv '${{ github.workspace }}/veristat.csv' \
+             '${{ github.workspace }}/veristat-baseline.csv'
+
+      - if: ${{ github.event_name == 'push' }}
+        uses: actions/cache/save@v3
+        with:
+          key: ${{ env.arch_and_tool }}-veristat-baseline-${{ github.run_id }}
+          path: '${{ github.workspace }}/veristat-baseline.csv'

--- a/ci/vmtest/run_selftests.sh
+++ b/ci/vmtest/run_selftests.sh
@@ -15,6 +15,7 @@ source "$(cd "$(dirname "$0")" && pwd)/helpers.sh"
 ARCH=$(uname -m)
 
 STATUS_FILE=/exitstatus
+OUTPUT_DIR=/command_output
 
 declare -a TEST_NAMES=()
 
@@ -96,6 +97,17 @@ test_verifier() {
   ./test_verifier && true
   echo "test_verifier:$?" >>"${STATUS_FILE}"
   foldable end test_verifier
+}
+
+run_veristat() {
+  foldable start run_veristat "Running veristat"
+
+  globs=$(awk '/^#/ { next; } { print $0 ".bpf.o"; }' ./veristat.cfg)
+  mkdir -p ${OUTPUT_DIR}
+  ./veristat -o csv -q -e file,prog,verdict,states ${globs} > ${OUTPUT_DIR}/veristat.csv
+  echo "run_veristat:$?" >> ${STATUS_FILE}
+
+  foldable end run_veristat
 }
 
 foldable end vm_init


### PR DESCRIPTION
Adds a job to execute veristat on a selected set of object files as a part of the general test pipeline. The job is executed differently for pushes and for pull requests:

- For pushes:
  - the kernel is compiled as usual;
  - selftests are compiled as well, this is necessary to produce object files that would be used by veristat;
  - veristat is executed inside qemu, performance statistics is collected and cached as baseline data.

- For pull requests:
  - veristat is executed inside qemu and performance statistics is collected;
  - baseline data is restored from cache;
  - baseline data is compared to current statistics and step summary page is formed;
  - if there are some programs that verified successfully in the baseline but fail verification in current run, the step is marked as failed.

This also adds 'run_veristat' "entrypoint" for run_selftests.sh.

This entrypoint executes veristat on a set of binary files specified in `./tools/testing/selftests/bpf/veristat.cfg` file and saves output to the `/command_output/` directory within qemu image. This output is extracted from the image by `run-qemu` action.

This pull request depends on the following pull requests for libbpf/ci repository:
- https://github.com/libbpf/ci/pull/98
- https://github.com/libbpf/ci/pull/99

I tested these changes using my own fork of the https://github.com/kernel-patches/bpf repository.
For test purposes I had to do some adjustments compared to production:
- minimize set of tests;
- change 'runs_on' actions to execution on my machine;
- link to eddyz87/libbpf-ci instead of eddyz87/libbpf/ci where appropriate.

Here are example runs:
- CI run for push to 'bpf-next':
  https://github.com/eddyz87/bpf/actions/runs/4692697761

- CI run for feature branch that breaks verification for some of the files
  (note the 'Summary' page, same info is duplicated in the text log for the `veristat` job):
  https://github.com/eddyz87/bpf/actions/runs/4692808046

- CI run for feature that does not change verification results:
  https://github.com/eddyz87/bpf/actions/runs/4692963478