### PR TITLE
run set-matrix on self-hosted runners for kernel-patches org

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
   set-matrix:
-    runs-on: ubuntu-latest
+    # FIXME: set-matrix is lightweight, run it on any self-hosted machines for kernel-patches org
+    # so we do not wait for GH hosted runners when there potentially all are busy because of bpf-rc
+    # repo for instance.
+    # This could be somehow fixed long term by making this action/workflow re-usable and letting the called
+    # specify what to run on.
+    runs-on: ${{ github.repository_owner == 'kernel-patches' && 'self-hosted' || 'ubuntu-latest' }}
     outputs:
       build-matrix: ${{ steps.set-matrix-impl.outputs.build_matrix }}
       test-matrix: ${{ steps.set-matrix-impl.outputs.test_matrix }}


### PR DESCRIPTION
With bpf-rc repo using GH hosted runners, we have seen cases when bpf actions are waiting on a GH runner. An org is limited to 20 GH runners, when multiple series are being processed, we max them out and bpf repo, which predominantly runs on self-hosted runners, is being idle waiting for a GH runner to free up, perform the action in a couple of seconds and move on.

This change will run set-matrix on any self-hosted machine free and ready to take an action. It does not need any specific arch, so let's pick whatever.
This mean that we will possibly run set-matrix for repo that are not running off self-hosted, on self-hosted, but that should not be a problem. in term of resources.

Here the trick is to evaluate the runner to use as part of a github action expresion so it is executed by github, and not the runner.