### PR TITLE
run set-matrix on x86_64 self-hosted

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     # repo for instance.
     # This could be somehow fixed long term by making this action/workflow re-usable and letting the called
     # specify what to run on.
-    runs-on: ${{ github.repository_owner == 'kernel-patches' && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository_owner == 'kernel-patches' && 'x86_64' || 'ubuntu-latest' }}
     outputs:
       build-matrix: ${{ steps.set-matrix-impl.outputs.build_matrix }}
       test-matrix: ${{ steps.set-matrix-impl.outputs.test_matrix }}


### PR DESCRIPTION
For some reason, even though python3 (kernel-patches/runner#23)is installed in s390x runners we still get an error about missing python3 when set-matrix runs off s390x runners:
https://github.com/kernel-patches/bpf/actions/runs/4827368579/jobs/8617270672#step:2:95

Troubleshooting will happen separately, but for now, let's mitigate by forcing running this step on self-hosted + x86_64 runners when the workflow is ran as part of a repository under `kernel-patches` org.