### PR TITLE
Enable xtrace when run_selftests.sh:run_veristat() is executed

### DIFF
--- a/ci/vmtest/run_selftests.sh
+++ b/ci/vmtest/run_selftests.sh
@@ -102,10 +102,23 @@ test_verifier() {
 run_veristat() {
   foldable start run_veristat "Running veristat"
 
+  # Make veristat commands visible in the log
+  if [ -o xtrace ]; then
+      xtrace_was_on="1"
+  else
+      xtrace_was_on=""
+      set -x
+  fi
+
   globs=$(awk '/^#/ { next; } { print $0 ".bpf.o"; }' ./veristat.cfg)
   mkdir -p ${OUTPUT_DIR}
   ./veristat -o csv -q -e file,prog,verdict,states ${globs} > ${OUTPUT_DIR}/veristat.csv
   echo "run_veristat:$?" >> ${STATUS_FILE}
+
+  # Hide commands again
+  if [ -z "$xtrace_was_on" ]; then
+      set +x
+  fi
 
   foldable end run_veristat
 }


### PR DESCRIPTION
Gain some better visibility for files selected for veristat processing by enabling xtrace inside `run_veristat` function. After this update log output looks as follows:

    ...
    run_veristat - Running veristat
      ++ awk '/^#/ { next; } { print $0 ".bpf.o"; }' ./veristat.cfg
      + globs='bpf_flow*.bpf.o
      bpf_loop_bench*.bpf.o
      ...
      xdp_synproxy*.bpf.o'
      + mkdir -p /command_output
      + ./veristat -o csv -q -e file,prog,verdict,states bpf_flow.bpf.o ...
      Failed to open 'test_usdt_multispec.bpf.o': -2
      + echo run_veristat:0
      + '[' -z '' ']'
      + set +x
    ...
