### PR TITLE
ci: temporary fixes from bpf tree to fix bpf-next tree's empty_skb

### DIFF
--- a/ci/diffs/0001-bpf-Clarify-error-expectations-from-bpf_clone_redire.patch
+++ b/ci/diffs/0001-bpf-Clarify-error-expectations-from-bpf_clone_redire.patch
@@ -1,0 +1,58 @@
+From 7cb779a6867fea00b4209bcf6de2f178a743247d Mon Sep 17 00:00:00 2001
+From: Stanislav Fomichev <sdf@google.com>
+Date: Mon, 11 Sep 2023 12:47:30 -0700
+Subject: [PATCH 1/2] bpf: Clarify error expectations from bpf_clone_redirect
+
+Commit 151e887d8ff9 ("veth: Fixing transmit return status for dropped
+packets") exposed the fact that bpf_clone_redirect is capable of
+returning raw NET_XMIT_XXX return codes.
+
+This is in the conflict with its UAPI doc which says the following:
+"0 on success, or a negative error in case of failure."
+
+Update the UAPI to reflect the fact that bpf_clone_redirect can
+return positive error numbers, but don't explicitly define
+their meaning.
+
+Reported-by: Daniel Borkmann <daniel@iogearbox.net>
+Signed-off-by: Stanislav Fomichev <sdf@google.com>
+Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>
+Link: https://lore.kernel.org/bpf/20230911194731.286342-1-sdf@google.com
+---
+ include/uapi/linux/bpf.h       | 4 +++-
+ tools/include/uapi/linux/bpf.h | 4 +++-
+ 2 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/include/uapi/linux/bpf.h b/include/uapi/linux/bpf.h
+index 8790b3962e4b..0448700890f7 100644
+--- a/include/uapi/linux/bpf.h
++++ b/include/uapi/linux/bpf.h
+@@ -1962,7 +1962,9 @@ union bpf_attr {
+  * 		performed again, if the helper is used in combination with
+  * 		direct packet access.
+  * 	Return
+- * 		0 on success, or a negative error in case of failure.
++ * 		0 on success, or a negative error in case of failure. Positive
++ * 		error indicates a potential drop or congestion in the target
++ * 		device. The particular positive error codes are not defined.
+  *
+  * u64 bpf_get_current_pid_tgid(void)
+  * 	Description
+diff --git a/tools/include/uapi/linux/bpf.h b/tools/include/uapi/linux/bpf.h
+index 8790b3962e4b..0448700890f7 100644
+--- a/tools/include/uapi/linux/bpf.h
++++ b/tools/include/uapi/linux/bpf.h
+@@ -1962,7 +1962,9 @@ union bpf_attr {
+  * 		performed again, if the helper is used in combination with
+  * 		direct packet access.
+  * 	Return
+- * 		0 on success, or a negative error in case of failure.
++ * 		0 on success, or a negative error in case of failure. Positive
++ * 		error indicates a potential drop or congestion in the target
++ * 		device. The particular positive error codes are not defined.
+  *
+  * u64 bpf_get_current_pid_tgid(void)
+  * 	Description
+-- 
+2.34.1
+

--- a/ci/diffs/0002-selftests-bpf-Update-bpf_clone_redirect-expected-ret.patch
+++ b/ci/diffs/0002-selftests-bpf-Update-bpf_clone_redirect-expected-ret.patch
@@ -1,0 +1,82 @@
+From b772b70b69046c5b76e3f2eda680f692dee5e6d5 Mon Sep 17 00:00:00 2001
+From: Stanislav Fomichev <sdf@google.com>
+Date: Mon, 11 Sep 2023 12:47:31 -0700
+Subject: [PATCH 2/2] selftests/bpf: Update bpf_clone_redirect expected return
+ code
+
+Commit 151e887d8ff9 ("veth: Fixing transmit return status for dropped
+packets") started propagating proper NET_XMIT_DROP error to the caller
+which means it's now possible to get positive error code when calling
+bpf_clone_redirect() in this particular test. Update the test to reflect
+that.
+
+Reported-by: Daniel Borkmann <daniel@iogearbox.net>
+Signed-off-by: Stanislav Fomichev <sdf@google.com>
+Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>
+Link: https://lore.kernel.org/bpf/20230911194731.286342-2-sdf@google.com
+---
+ tools/testing/selftests/bpf/prog_tests/empty_skb.c | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/tools/testing/selftests/bpf/prog_tests/empty_skb.c b/tools/testing/selftests/bpf/prog_tests/empty_skb.c
+index 3b77d8a422db..261228eb68e8 100644
+--- a/tools/testing/selftests/bpf/prog_tests/empty_skb.c
++++ b/tools/testing/selftests/bpf/prog_tests/empty_skb.c
+@@ -24,6 +24,7 @@ void test_empty_skb(void)
+ 		int *ifindex;
+ 		int err;
+ 		int ret;
++		int lwt_egress_ret; /* expected retval at lwt/egress */
+ 		bool success_on_tc;
+ 	} tests[] = {
+ 		/* Empty packets are always rejected. */
+@@ -57,6 +58,7 @@ void test_empty_skb(void)
+ 			.data_size_in = sizeof(eth_hlen),
+ 			.ifindex = &veth_ifindex,
+ 			.ret = -ERANGE,
++			.lwt_egress_ret = -ERANGE,
+ 			.success_on_tc = true,
+ 		},
+ 		{
+@@ -70,6 +72,7 @@ void test_empty_skb(void)
+ 			.data_size_in = sizeof(eth_hlen),
+ 			.ifindex = &ipip_ifindex,
+ 			.ret = -ERANGE,
++			.lwt_egress_ret = -ERANGE,
+ 		},
+ 
+ 		/* ETH_HLEN+1-sized packet should be redirected. */
+@@ -79,6 +82,7 @@ void test_empty_skb(void)
+ 			.data_in = eth_hlen_pp,
+ 			.data_size_in = sizeof(eth_hlen_pp),
+ 			.ifindex = &veth_ifindex,
++			.lwt_egress_ret = 1, /* veth_xmit NET_XMIT_DROP */
+ 		},
+ 		{
+ 			.msg = "ipip ETH_HLEN+1 packet ingress",
+@@ -108,8 +112,12 @@ void test_empty_skb(void)
+ 
+ 	for (i = 0; i < ARRAY_SIZE(tests); i++) {
+ 		bpf_object__for_each_program(prog, bpf_obj->obj) {
+-			char buf[128];
++			bool at_egress = strstr(bpf_program__name(prog), "egress") != NULL;
+ 			bool at_tc = !strncmp(bpf_program__section_name(prog), "tc", 2);
++			int expected_ret;
++			char buf[128];
++
++			expected_ret = at_egress && !at_tc ? tests[i].lwt_egress_ret : tests[i].ret;
+ 
+ 			tattr.data_in = tests[i].data_in;
+ 			tattr.data_size_in = tests[i].data_size_in;
+@@ -128,7 +136,7 @@ void test_empty_skb(void)
+ 			if (at_tc && tests[i].success_on_tc)
+ 				ASSERT_GE(bpf_obj->bss->ret, 0, buf);
+ 			else
+-				ASSERT_EQ(bpf_obj->bss->ret, tests[i].ret, buf);
++				ASSERT_EQ(bpf_obj->bss->ret, expected_ret, buf);
+ 		}
+ 	}
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
Backport two patches fixing empty_skb selftest.