### PR TITLE
Fix veristat baseline cache save/restore

### DIFF
--- a/.github/actions/veristat_baseline_compare/action.yml
+++ b/.github/actions/veristat_baseline_compare/action.yml
@@ -1,18 +1,18 @@
 name: 'run-veristat'
 description: 'Run veristat benchmark'
 inputs:
-  arch_and_tool:
-    description: 'arch and build tool string'
-    required: true
   veristat_output:
-    description: 'veristat output'
+    description: 'Veristat output filepath'
+    required: true
+  baseline_name:
+    description: 'Veristat baseline cache name'
     required: true
 runs:
   using: "composite"
   steps:
     - uses: actions/upload-artifact@v3
       with:
-        name: ${{ inputs.arch_and_tool }}-baseline-${{ inputs.veristat_output }}
+        name: ${{ inputs.baseline_name }}
         if-no-files-found: error
         path: ${{ github.workspace }}/${{ inputs.veristat_output }}
 
@@ -22,27 +22,28 @@ runs:
     - if: ${{ github.event_name == 'pull_request' }}
       uses: actions/cache/restore@v3
       with:
-        key: ${{ env.CACHE_RESULT_KEY }}
+        key: ${{ inputs.baseline_name }}
         restore-keys: |
-          ${{ env.CACHE_RESULT_KEY }}-
-        path: '${{ env.CACHE_RESULT_KEY }}'
-      env:
-        CACHE_RESULT_KEY: ${{ inputs.arch_and_tool }}-baseline-${{ inputs.veristat_output }}
+          ${{ inputs.baseline_name }}-
+        path: '${{ github.workspace }}/${{ inputs.baseline_name }}'
 
     - if: ${{ github.event_name == 'pull_request' }}
       name: Show veristat comparison
       shell: bash
       run: ./.github/scripts/compare-veristat-results.sh
       env:
-        CACHE_RESULT_KEY: ${{ inputs.arch_and_tool }}-baseline-${{ inputs.veristat_output }}
+        BASELINE_PATH: ${{ github.workspace }}/${{ inputs.baseline_name }}
         VERISTAT_OUTPUT: ${{ inputs.veristat_output }}
 
     # For push: just put baseline log to cache
     - if: ${{ github.event_name == 'push' }}
+      shell: bash
+      run: |
+        mv "${{ github.workspace }}/${{ inputs.veristat_output }}" \
+           "${{ github.workspace }}/${{ inputs.baseline_name }}"
+
+    - if: ${{ github.event_name == 'push' }}
       uses: actions/cache/save@v3
       with:
         key: ${{ env.CACHE_RESULT_KEY }}-${{ github.run_id }}
-        path: '${{ github.workspace }}/${{ inputs.veristat_output }}'
-      env:
-        CACHE_RESULT_KEY: ${{ inputs.arch_and_tool }}-baseline-${{ inputs.veristat_output }}
-
+        path: '${{ github.workspace }}/${{ inputs.baseline_name }}'

--- a/.github/scripts/compare-veristat-results.sh
+++ b/.github/scripts/compare-veristat-results.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-if [[ ! -f "${CACHE_RESULT_KEY}" ]]; then
-    echo "# No ${CACHE_RESULT_KEY} available" >> "${GITHUB_STEP_SUMMARY}"
+if [[ ! -f "${BASELINE_PATH}" ]]; then
+    echo "# No ${BASELINE_PATH} available" >> "${GITHUB_STEP_SUMMARY}"
 
-    echo "No ${CACHE_RESULT_KEY} available"
+    echo "No ${BASELINE_PATH} available"
     echo "Printing veristat results"
     cat "${VERISTAT_OUTPUT}"
 
@@ -13,6 +13,6 @@ fi
 selftests/bpf/veristat \
     --output-format csv \
     --emit file,prog,verdict,states \
-    --compare "${CACHE_RESULT_KEY}" "${VERISTAT_OUTPUT}" > compare.csv
+    --compare "${BASELINE_PATH}" "${VERISTAT_OUTPUT}" > compare.csv
 
 python3 ./.github/scripts/veristat-compare.py compare.csv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,11 +243,11 @@ jobs:
       - name: Compare and save veristat.kernel.csv
         uses: ./.github/actions/veristat_baseline_compare
         with:
-          arch_and_tool: ${{ env.ARCH_AND_TOOL}}
           veristat_output: veristat-kernel
+          baseline_name: ${{ env.ARCH_AND_TOOL}}-baseline-veristat-kernel
 
       - name: Compare and save veristat.meta.csv
         uses: ./.github/actions/veristat_baseline_compare
         with:
-          arch_and_tool: ${{ env.ARCH_AND_TOOL}}
           veristat_output: veristat-meta
+          baseline_name: ${{ env.ARCH_AND_TOOL}}-baseline-veristat-meta


### PR DESCRIPTION
Github cache has S3-like structure, where key is a bucket and files specified in the path argument makes its content.
Due to that fact save and restore actions MUST have the same path argument.