### PR TITLE
Skip veristat validation with Meta objects for PRs from forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,6 +209,10 @@ jobs:
           image-output: '/tmp/root.img'
 
       - name: Configure AWS Credentials
+        # Disabling BPF objects download and veristat-meta benchmark for PRs
+        # created from fork repositories. These won't have access to required
+        # enviroment variables and secrets, and otherwise would consistently fail
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: ${{ vars.AWS_REGION }}
@@ -216,6 +220,7 @@ jobs:
           role-session-name: github-action-bpf-ci
 
       - name: Download BPF objects
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           set -eux
           if [ -n "$AWS_ROLE_ARN" ]; then
@@ -226,6 +231,7 @@ jobs:
           AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
 
       - name: Add BPF objects to rootfs
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         shell: bash
         run: ./.github/scripts/bpf-objects-rootfs.sh
 
@@ -247,6 +253,7 @@ jobs:
           baseline_name: ${{ env.ARCH_AND_TOOL}}-baseline-veristat-kernel
 
       - name: Compare and save veristat.meta.csv
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: ./.github/actions/veristat_baseline_compare
         with:
           veristat_output: veristat-meta


### PR DESCRIPTION
Github actions doesn't allow to access both variable and secrets for workflows triggered by pull requests from forked repositories.

Disabling veristat validation with Meta objects for such PRs since workflow won't be able to download objects due to missing secrets.

Example workflow run: https://github.com/kernel-patches/bpf/actions/runs/6412314917/job/17409487960