### PR TITLE
Add unittests for veristat_compare script

### DIFF
--- a/.github/scripts/compare-veristat-results.sh
+++ b/.github/scripts/compare-veristat-results.sh
@@ -15,4 +15,4 @@ selftests/bpf/veristat \
     --emit file,prog,verdict,states \
     --compare "${BASELINE_PATH}" "${VERISTAT_OUTPUT}" > compare.csv
 
-python3 ./.github/scripts/veristat-compare.py compare.csv
+python3 ./.github/scripts/veristat_compare.py compare.csv

--- a/.github/scripts/tests/test_veristat_compare.py
+++ b/.github/scripts/tests/test_veristat_compare.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+import unittest
+from typing import Iterable, List
+
+from ..veristat_compare import parse_table, VeristatFields
+
+
+def gen_csv_table(records: Iterable[str]) -> List[str]:
+    return [
+        ",".join(VeristatFields.headers()),
+        *records,
+    ]
+
+
+class TestVeristatCompare(unittest.TestCase):
+    def test_parse_table_ignore_new_prog(self):
+        table = gen_csv_table(
+            [
+                "prog_file.bpf.o,prog_name,N/A,success,N/A,N/A,1,N/A",
+            ]
+        )
+        veristat_info = parse_table(table)
+        self.assertEqual(veristat_info.table, [])
+        self.assertFalse(veristat_info.changes)
+        self.assertFalse(veristat_info.new_failures)
+
+    def test_parse_table_ignore_removed_prog(self):
+        table = gen_csv_table(
+            [
+                "prog_file.bpf.o,prog_name,success,N/A,N/A,1,N/A,N/A",
+            ]
+        )
+        veristat_info = parse_table(table)
+        self.assertEqual(veristat_info.table, [])
+        self.assertFalse(veristat_info.changes)
+        self.assertFalse(veristat_info.new_failures)
+
+    def test_parse_table_new_failure(self):
+        table = gen_csv_table(
+            [
+                "prog_file.bpf.o,prog_name,success,failure,MISMATCH,1,1,+0 (+0.00%)",
+            ]
+        )
+        veristat_info = parse_table(table)
+        self.assertEqual(
+            veristat_info.table,
+            [["prog_file.bpf.o", "prog_name", "success -> failure (!!)", "+0.00 %"]],
+        )
+        self.assertTrue(veristat_info.changes)
+        self.assertTrue(veristat_info.new_failures)
+
+    def test_parse_table_new_changes(self):
+        table = gen_csv_table(
+            [
+                "prog_file.bpf.o,prog_name,failure,success,MISMATCH,0,0,+0 (+0.00%)",
+                "prog_file.bpf.o,prog_name_increase,failure,failure,MATCH,1,2,+1 (+100.00%)",
+                "prog_file.bpf.o,prog_name_decrease,success,success,MATCH,1,1,-1 (-100.00%)",
+            ]
+        )
+        veristat_info = parse_table(table)
+        self.assertEqual(
+            veristat_info.table,
+            [
+                ["prog_file.bpf.o", "prog_name", "failure -> success", "+0.00 %"],
+                ["prog_file.bpf.o", "prog_name_increase", "failure", "+100.00 %"],
+                ["prog_file.bpf.o", "prog_name_decrease", "success", "-100.00 %"],
+            ],
+        )
+        self.assertTrue(veristat_info.changes)
+        self.assertFalse(veristat_info.new_failures)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/veristat_compare.py
+++ b/.github/scripts/veristat_compare.py
@@ -44,7 +44,7 @@ import logging
 import argparse
 import enum
 from dataclasses import dataclass
-from typing import Dict, List, Final
+from typing import Dict, Iterable, List, Final
 
 
 TRESHOLD_PCT: Final[int] = 0
@@ -153,7 +153,7 @@ def get_state_diff(value: str) -> float:
     raise ValueError(f"Invalid {VeristatFields.TOTAL_STATES_DIFF} field value: {value}")
 
 
-def parse_table(csv_file):
+def parse_table(csv_file: Iterable[str]) -> VeristatInfo:
     reader = csv.DictReader(csv_file)
     assert reader.fieldnames == VeristatFields.headers()
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,3 +53,13 @@ jobs:
         run: |
           python3 .github/scripts/matrix.py
 
+  unittests:
+    if: ${{ github.repository == 'kernel-patches/vmtest' }}
+    name: Unittests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Run unittests
+        run: python3 -m unittest scripts/tests/*.py
+        working-directory: .github

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+*.pyc


### PR DESCRIPTION
- Rename veristat-compare.py into veristat_compare.py to match python naming convention
- Add unittests for parse_tables() method