### PR TITLE
tests: Run parallel tests on x86_64/gcc only

### DIFF
--- a/.github/scripts/matrix.py
+++ b/.github/scripts/matrix.py
@@ -51,7 +51,7 @@ def get_tests(config):
         "test_maps",
         "test_verifier",
     ]
-    if config.get("parallel_tests", True):
+    if config.get("parallel_tests", False):
         return tests
     return [test for test in tests if not test.endswith("parallel")]
 
@@ -64,6 +64,7 @@ matrix = [
         "toolchain": "gcc",
         "llvm-version": "16",
         "run_veristat": True,
+        "parallel_tests": True,
     },
     {
         "kernel": "LATEST",
@@ -92,7 +93,6 @@ matrix = [
         "arch": Arch.S390X.value,
         "toolchain": "gcc",
         "llvm-version": "16",
-        "parallel_tests": False,
     },
 ]
 self_hosted_repos = [


### PR DESCRIPTION
This changes the logic as to where we run parallel tests to only gcc/x86_64 setup.

We still want to get some signal from those tests, but don't need to have them running on all arch/toolchain pairs.
```
$ GITHUB_REPOSITORY_OWNER=kernel-patches GITHUB_REPOSITORY=kernel-patches/vmtest GITHUB_OUTPUT=/dev/stdout python3 .github/scripts/matrix.py   | cut -d= -f2- | jq . > /tmp/new
$ diff -ruN  /tmp/old /tmp/new
--- /tmp/old	2023-10-26 18:21:56
+++ /tmp/new	2023-10-26 18:22:56
@@ -10,6 +10,7 @@
       "toolchain": "gcc",
       "llvm-version": "16",
       "run_veristat": true,
+      "parallel_tests": true,
       "toolchain_full": "gcc",
       "tests": {
         "include": [
@@ -65,21 +66,11 @@
             "timeout_minutes": 360
           },
           {
-            "test": "test_progs_parallel",
-            "continue_on_error": true,
-            "timeout_minutes": 30
-          },
-          {
             "test": "test_progs_no_alu32",
             "continue_on_error": false,
             "timeout_minutes": 360
           },
           {
-            "test": "test_progs_no_alu32_parallel",
-            "continue_on_error": true,
-            "timeout_minutes": 30
-          },
-          {
             "test": "test_maps",
             "continue_on_error": false,
             "timeout_minutes": 360
@@ -111,21 +102,11 @@
             "timeout_minutes": 360
           },
           {
-            "test": "test_progs_parallel",
-            "continue_on_error": true,
-            "timeout_minutes": 30
-          },
-          {
             "test": "test_progs_no_alu32",
             "continue_on_error": false,
             "timeout_minutes": 360
           },
           {
-            "test": "test_progs_no_alu32_parallel",
-            "continue_on_error": true,
-            "timeout_minutes": 30
-          },
-          {
             "test": "test_maps",
             "continue_on_error": false,
             "timeout_minutes": 360
@@ -147,7 +128,6 @@
       "arch": "s390x",
       "toolchain": "gcc",
       "llvm-version": "16",
-      "parallel_tests": false,
       "toolchain_full": "gcc",
       "run_veristat": false,
       "tests": {
```