### PR TITLE
Add release test_progs build

### DIFF
--- a/.github/scripts/matrix.py
+++ b/.github/scripts/matrix.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-from copy import deepcopy
 from json import dumps
 from enum import Enum
 import os
@@ -72,6 +71,7 @@ matrix = [
         "arch": Arch.X86_64.value,
         "toolchain": "llvm",
         "llvm-version": "17",
+        "build_release": True,
     },
     {
         "kernel": "LATEST",
@@ -79,6 +79,7 @@ matrix = [
         "arch": Arch.X86_64.value,
         "toolchain": "llvm",
         "llvm-version": "18",
+        "build_release": True,
     },
     {
         "kernel": "LATEST",
@@ -115,6 +116,8 @@ for idx in range(len(matrix) - 1, -1, -1):
 
     # Set run_veristat to false by default.
     matrix[idx]["run_veristat"] = matrix[idx].get("run_veristat", False)
+    # Set build_release to false by default.
+    matrix[idx]["build_release"] = matrix[idx].get("build_release", False)
     # Feel in the tests
     matrix[idx]["tests"] = {
         "include": [generate_test_config(test) for test in get_tests(matrix[idx])]

--- a/.github/workflows/kernel-build-test.yml
+++ b/.github/workflows/kernel-build-test.yml
@@ -44,6 +44,11 @@ on:
         type: boolean
         description: Whether to download the linux sources into the working directory.
         default: false
+      build_release:
+        required: true
+        type: boolean
+        description: Build selftests with -O2 optimization in addition to non-optimized build.
+        default: false
     secrets:
       AWS_ROLE_ARN:
         required: true
@@ -60,7 +65,18 @@ jobs:
       llvm-version: ${{ inputs.llvm-version }}
       kernel: ${{ inputs.kernel }}
       download_sources: ${{ inputs.download_sources }}
-
+  build-release:
+    if: ${{ inputs.build_release }}
+    uses: ./.github/workflows/kernel-build.yml
+    with:
+      arch: ${{ inputs.arch }}
+      toolchain_full: ${{ inputs.toolchain_full }}
+      toolchain: ${{ inputs.toolchain }}
+      runs_on: ${{ inputs.runs_on }}
+      llvm-version: ${{ inputs.llvm-version }}
+      kernel: ${{ inputs.kernel }}
+      download_sources: ${{ inputs.download_sources }}
+      release: true
   test:
     if: ${{ inputs.run_tests }}
     uses: ./.github/workflows/kernel-test.yml

--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -33,11 +33,15 @@ on:
         type: boolean
         description: Whether to download the linux sources into the working directory.
         default: false
+      release:
+        required: false
+        type: boolean
+        description: Build selftest with -O2 optimization
+        default: false
 
- 
 jobs:
   build:
-    name: build for ${{ inputs.arch }} with ${{ inputs.toolchain_full }}
+    name: build for ${{ inputs.arch }} with ${{ inputs.toolchain_full }} ${{ inputs.release && 'and -O2 optimization' || '' }}
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: 100
     env:
@@ -103,6 +107,11 @@ jobs:
           kbuild-output: ${{ env.KBUILD_OUTPUT }}
           max-make-jobs: 32
           llvm-version: ${{ inputs.llvm-version }}
+        env:
+          # RELEASE= disables all optimizaions
+          # RELEASE=0 adds -O0 make flag
+          # RELEASE=1 adds -O2 make flag
+          RELEASE: ${{ inputs.release && '1' || '' }}
       - if: ${{ github.event_name != 'push' }}
         name: Build samples
         uses: libbpf/ci/build-samples@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,5 +52,6 @@ jobs:
       run_tests: ${{ github.event_name != 'push' }}
       # Download sources
       download_sources: ${{ github.repository == 'kernel-patches/vmtest' }}
+      build_release: ${{ matrix.build_release }}
     secrets:
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}


### PR DESCRIPTION
In addition to default, build `test_prog` with `RELEASE=1` flags, adding `-O2` optimization. Currently it will only work for `llvm` due to fairly old version of `gcc` available on our `ubuntu-20.04` runners. Once we upgrade runners to the latest Ubuntu LTS release, we should be able to enable these builds for `gcc` as well. 