### PR TITLE
Add veristat.cfg for meta BPF objs

### DIFF
--- a/ci/vmtest/configs/run_veristat.kernel.cfg
+++ b/ci/vmtest/configs/run_veristat.kernel.cfg
@@ -1,3 +1,4 @@
-VERISTAT_OBJECTS_DIR="/${PROJECT_NAME}/selftests/bpf"
-VERISTAT_OBJECTS_GLOB=$(awk '/^#/ { next; } { print $0 ".bpf.o"; }' "${BPF_SELFTESTS_DIR}/veristat.cfg")
+VERISTAT_OBJECTS_DIR="${BPF_SELFTESTS_DIR}"
+VERISTAT_OBJECTS_GLOB="*.bpf.o"
+VERISTAT_CFG_FILE="${BPF_SELFTESTS_DIR}/veristat.cfg"
 VERISTAT_OUTPUT="veristat-kernel"

--- a/ci/vmtest/configs/run_veristat.meta.cfg
+++ b/ci/vmtest/configs/run_veristat.meta.cfg
@@ -1,3 +1,4 @@
 VERISTAT_OBJECTS_DIR="/bpf_objects"
 VERISTAT_OBJECTS_GLOB="*.o"
 VERISTAT_OUTPUT="veristat-meta"
+VERISTAT_CFG_FILE="${VMTEST_CONFIGS_PATH}/veristat_meta.cfg"

--- a/ci/vmtest/configs/veristat_meta.cfg
+++ b/ci/vmtest/configs/veristat_meta.cfg
@@ -1,0 +1,10 @@
+# List of exceptions we know about that are not going to work with veristat.
+
+# needs 'migrate_misplaced_page' which went away in
+# commit 73eab3ca481e ("mm: migrate: convert migrate_misplaced_page() to migrate_misplaced_folio()")
+!numamove_bpf-numamove_bpf.o
+
+# use non-libbpf loader
+!takeover_bpf_lib-takeover.bpf.o
+!tcp_tuner_bpf_lib-tcptuner.bpf.o
+

--- a/ci/vmtest/run_selftests.sh
+++ b/ci/vmtest/run_selftests.sh
@@ -133,7 +133,8 @@ run_veristat_helper() {
     mkdir -p ${OUTPUT_DIR}
     pushd "${VERISTAT_OBJECTS_DIR}"
 
-    "${BPF_SELFTESTS_DIR}/veristat" -o csv -q -e file,prog,verdict,states ${VERISTAT_OBJECTS_GLOB} > \
+    "${BPF_SELFTESTS_DIR}/veristat" -o csv -q -e file,prog,verdict,states \
+      -f "@${VERISTAT_CFG_FILE}" ${VERISTAT_OBJECTS_GLOB} > \
       "${OUTPUT_DIR}/${VERISTAT_OUTPUT}"
 
     echo "run_veristat_${mode}:$?" >> ${STATUS_FILE}


### PR DESCRIPTION
This PR adds a `veristat_meta.cfg` to this repository, meant to be used with the tarball of meta bpf objs.

`run_selftests.sh` is modified to use veristat.cfg files via veristat's `-f` flag. See individual commit summaries for more detail.