### PR TITLE
ci: bump minimum clang to 17 and add 18 to x86-64

### DIFF
--- a/.github/scripts/matrix.py
+++ b/.github/scripts/matrix.py
@@ -62,7 +62,7 @@ matrix = [
         "runs_on": [],
         "arch": Arch.X86_64.value,
         "toolchain": "gcc",
-        "llvm-version": "16",
+        "llvm-version": "17",
         "run_veristat": True,
         "parallel_tests": True,
     },
@@ -71,14 +71,21 @@ matrix = [
         "runs_on": [],
         "arch": Arch.X86_64.value,
         "toolchain": "llvm",
-        "llvm-version": "16",
+        "llvm-version": "17",
+    },
+    {
+        "kernel": "LATEST",
+        "runs_on": [],
+        "arch": Arch.X86_64.value,
+        "toolchain": "llvm",
+        "llvm-version": "18",
     },
     {
         "kernel": "LATEST",
         "runs_on": [],
         "arch": Arch.AARCH64.value,
         "toolchain": "gcc",
-        "llvm-version": "16",
+        "llvm-version": "17",
     },
     # {
     #     "kernel": "LATEST",
@@ -92,7 +99,7 @@ matrix = [
         "runs_on": [],
         "arch": Arch.S390X.value,
         "toolchain": "gcc",
-        "llvm-version": "16",
+        "llvm-version": "17",
     },
 ]
 self_hosted_repos = [


### PR DESCRIPTION
Use clang-17 now that it is stable. To catch issues in clang dev version, add clang-18 variant for llvm build on x86-64.