### PR TITLE
Remove usdt from DENYLIST.s390x

### DIFF
--- a/ci/vmtest/configs/DENYLIST.s390x
+++ b/ci/vmtest/configs/DENYLIST.s390x
@@ -1,5 +1,3 @@
 deny_namespace                           # not yet in bpf denylist
 tc_redirect/tc_redirect_dtime            # very flaky
 lru_bug                                  # not yet in bpf-next denylist
-usdt/basic                               # failing verifier due to bounds check after LLVM update
-usdt/multispec                           # same as above


### PR DESCRIPTION
usdt/basic and usdt/multispec tests seem to pass on s390x at the moment. Let's try unblocking them in the CI.

See the [test run](https://github.com/kernel-patches/bpf/actions/runs/7269307249/job/19807144377?pr=6175) that passed on https://github.com/kernel-patches/bpf/pull/6175