### PR TITLE
build: Always pass architecture to actions

### DIFF
--- a/.github/scripts/veristat_compare.py
+++ b/.github/scripts/veristat_compare.py
@@ -57,17 +57,16 @@ TOTAL_STATES_DIFF_REGEX = (
 )
 
 
-TEXT_SUMMARY_TEMPLATE: Final[
-    str
-] = """
+TEXT_SUMMARY_TEMPLATE: Final[str] = (
+    """
 # {title}
 
 {table}
 """.strip()
+)
 
-HTML_SUMMARY_TEMPLATE: Final[
-    str
-] = """
+HTML_SUMMARY_TEMPLATE: Final[str] = (
+    """
 # {title}
 
 <details>
@@ -76,6 +75,7 @@ HTML_SUMMARY_TEMPLATE: Final[
 {table}
 </details>
 """.strip()
+)
 
 GITHUB_MARKUP_REPLACEMENTS: Final[Dict[str, str]] = {
     "->": "&rarr;",

--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -103,6 +103,7 @@ jobs:
       - name: Build selftests
         uses: libbpf/ci/build-selftests@main
         with:
+          arch: ${{ inputs.arch }}
           toolchain: ${{ inputs.toolchain }}
           kbuild-output: ${{ env.KBUILD_OUTPUT }}
           max-make-jobs: 32
@@ -116,6 +117,7 @@ jobs:
         name: Build samples
         uses: libbpf/ci/build-samples@main
         with:
+          arch: ${{ inputs.arch }}
           toolchain: ${{ inputs.toolchain }}
           kbuild-output: ${{ env.KBUILD_OUTPUT }}
           max-make-jobs: 32


### PR DESCRIPTION
In preparation of cross-compiling, ensure that we always pass arch parameter to the action.
At a later stage, this parameter will be made required on libbpf-ci.