### PR TITLE
build: Also pass target arch to setup-env-build

### DIFF
--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Setup build environment
         uses: libbpf/ci/setup-build-env@main
         with:
+          arch: ${{ inputs.arch }}
           llvm-version: ${{ inputs.llvm-version }}
       - name: Build kernel image
         uses: libbpf/ci/build-linux@main


### PR DESCRIPTION
We will use this to find out whether or not to install cross-compilation toolchain. Similar to #261