### PR TITLE
ci: Change selftest cross compile patch

### DIFF
--- a/ci/diffs/0001-tools-resolve_btfids-fix-cross-compilation-to-non-host-endianness.patch
+++ b/ci/diffs/0001-tools-resolve_btfids-fix-cross-compilation-to-non-host-endianness.patch
@@ -1,7 +1,8 @@
-From 9707ac4fe2f5bac6406d2403f8b8a64d7b3d8e43 Mon Sep 17 00:00:00 2001
+From 3772e6cdb51f21a11df2acf6aa431cc8b9137bfb Mon Sep 17 00:00:00 2001
 From: Viktor Malik <vmalik@redhat.com>
 Date: Tue, 6 Feb 2024 13:46:09 +0100
-Subject: tools/resolve_btfids: Refactor set sorting with types from btf_ids.h
+Subject: [PATCH 1/2] tools/resolve_btfids: Refactor set sorting with types
+ from btf_ids.h
 
 Instead of using magic offsets to access BTF ID set data, leverage types
 from btf_ids.h (btf_id_set and btf_id_set8) which define the actual
@@ -19,12 +20,12 @@ Signed-off-by: Andrii Nakryiko <andrii@kernel.org>
 Acked-by: Daniel Xu <dxu@dxuuu.xyz>
 Link: https://lore.kernel.org/bpf/ff7f062ddf6a00815fda3087957c4ce667f50532.1707223196.git.vmalik@redhat.com
 ---
- tools/bpf/resolve_btfids/main.c | 35 +++++++++++++++++++++--------------
+ tools/bpf/resolve_btfids/main.c | 35 ++++++++++++++++++++-------------
  tools/include/linux/btf_ids.h   |  9 +++++++++
  2 files changed, 30 insertions(+), 14 deletions(-)
 
 diff --git a/tools/bpf/resolve_btfids/main.c b/tools/bpf/resolve_btfids/main.c
-index 27a23196d58e10..32634f00abba4a 100644
+index 27a23196d58e..32634f00abba 100644
 --- a/tools/bpf/resolve_btfids/main.c
 +++ b/tools/bpf/resolve_btfids/main.c
 @@ -70,6 +70,7 @@
@@ -115,7 +116,7 @@ index 27a23196d58e10..32634f00abba4a 100644
  		next = rb_next(next);
  	}
 diff --git a/tools/include/linux/btf_ids.h b/tools/include/linux/btf_ids.h
-index 2f882d5cb30f5c..72535f00572f6e 100644
+index 2f882d5cb30f..72535f00572f 100644
 --- a/tools/include/linux/btf_ids.h
 +++ b/tools/include/linux/btf_ids.h
 @@ -8,6 +8,15 @@ struct btf_id_set {
@@ -135,122 +136,7 @@ index 2f882d5cb30f5c..72535f00572f6e 100644
  
  #include <linux/compiler.h> /* for __PASTE */
 -- 
-cgit 1.2.3-korg
+2.39.3
 
 
-From 903fad4394666bc23975c93fb58f137ce64b5192 Mon Sep 17 00:00:00 2001
-From: Viktor Malik <vmalik@redhat.com>
-Date: Tue, 6 Feb 2024 13:46:10 +0100
-Subject: tools/resolve_btfids: Fix cross-compilation to non-host endianness
-
-The .BTF_ids section is pre-filled with zeroed BTF ID entries during the
-build and afterwards patched by resolve_btfids with correct values.
-Since resolve_btfids always writes in host-native endianness, it relies
-on libelf to do the translation when the target ELF is cross-compiled to
-a different endianness (this was introduced in commit 61e8aeda9398
-("bpf: Fix libelf endian handling in resolv_btfids")).
-
-Unfortunately, the translation will corrupt the flags fields of SET8
-entries because these were written during vmlinux compilation and are in
-the correct endianness already. This will lead to numerous selftests
-failures such as:
-
-    $ sudo ./test_verifier 502 502
-    #502/p sleepable fentry accept FAIL
-    Failed to load prog 'Invalid argument'!
-    bpf_fentry_test1 is not sleepable
-    verification time 34 usec
-    stack depth 0
-    processed 0 insns (limit 1000000) max_states_per_insn 0 total_states 0 peak_states 0 mark_read 0
-    Summary: 0 PASSED, 0 SKIPPED, 1 FAILED
-
-Since it's not possible to instruct libelf to translate just certain
-values, let's manually bswap the flags (both global and entry flags) in
-resolve_btfids when needed, so that libelf then translates everything
-correctly.
-
-Fixes: ef2c6f370a63 ("tools/resolve_btfids: Add support for 8-byte BTF sets")
-Signed-off-by: Viktor Malik <vmalik@redhat.com>
-Signed-off-by: Andrii Nakryiko <andrii@kernel.org>
-Link: https://lore.kernel.org/bpf/7b6bff690919555574ce0f13d2a5996cacf7bf69.1707223196.git.vmalik@redhat.com
----
- tools/bpf/resolve_btfids/main.c | 35 +++++++++++++++++++++++++++++++++++
- 1 file changed, 35 insertions(+)
-
-diff --git a/tools/bpf/resolve_btfids/main.c b/tools/bpf/resolve_btfids/main.c
-index 32634f00abba4a..d9520cb826b31f 100644
---- a/tools/bpf/resolve_btfids/main.c
-+++ b/tools/bpf/resolve_btfids/main.c
-@@ -90,6 +90,14 @@
- 
- #define ADDR_CNT	100
- 
-+#if __BYTE_ORDER == __LITTLE_ENDIAN
-+# define ELFDATANATIVE	ELFDATA2LSB
-+#elif __BYTE_ORDER == __BIG_ENDIAN
-+# define ELFDATANATIVE	ELFDATA2MSB
-+#else
-+# error "Unknown machine endianness!"
-+#endif
-+
- struct btf_id {
- 	struct rb_node	 rb_node;
- 	char		*name;
-@@ -117,6 +125,7 @@ struct object {
- 		int		 idlist_shndx;
- 		size_t		 strtabidx;
- 		unsigned long	 idlist_addr;
-+		int		 encoding;
- 	} efile;
- 
- 	struct rb_root	sets;
-@@ -320,6 +329,7 @@ static int elf_collect(struct object *obj)
- {
- 	Elf_Scn *scn = NULL;
- 	size_t shdrstrndx;
-+	GElf_Ehdr ehdr;
- 	int idx = 0;
- 	Elf *elf;
- 	int fd;
-@@ -351,6 +361,13 @@ static int elf_collect(struct object *obj)
- 		return -1;
- 	}
- 
-+	if (gelf_getehdr(obj->efile.elf, &ehdr) == NULL) {
-+		pr_err("FAILED cannot get ELF header: %s\n",
-+			elf_errmsg(-1));
-+		return -1;
-+	}
-+	obj->efile.encoding = ehdr.e_ident[EI_DATA];
-+
- 	/*
- 	 * Scan all the elf sections and look for save data
- 	 * from .BTF_ids section and symbols.
-@@ -681,6 +698,24 @@ static int sets_patch(struct object *obj)
- 			 */
- 			BUILD_BUG_ON(set8->pairs != &set8->pairs[0].id);
- 			qsort(set8->pairs, set8->cnt, sizeof(set8->pairs[0]), cmp_id);
-+
-+			/*
-+			 * When ELF endianness does not match endianness of the
-+			 * host, libelf will do the translation when updating
-+			 * the ELF. This, however, corrupts SET8 flags which are
-+			 * already in the target endianness. So, let's bswap
-+			 * them to the host endianness and libelf will then
-+			 * correctly translate everything.
-+			 */
-+			if (obj->efile.encoding != ELFDATANATIVE) {
-+				int i;
-+
-+				set8->flags = bswap_32(set8->flags);
-+				for (i = 0; i < set8->cnt; i++) {
-+					set8->pairs[i].flags =
-+						bswap_32(set8->pairs[i].flags);
-+				}
-+			}
- 		}
- 
- 		pr_debug("sorting  addr %5lu: cnt %6d [%s]\n",
--- 
-cgit 1.2.3-korg
 

--- a/ci/diffs/0002-tools-resolve_btfids-fix-cross-compilation-to-non-host-endianness.patch
+++ b/ci/diffs/0002-tools-resolve_btfids-fix-cross-compilation-to-non-host-endianness.patch
@@ -1,0 +1,117 @@
+From c3dcadfdf2bf8f01471066700c098b5185240df6 Mon Sep 17 00:00:00 2001
+From: Viktor Malik <vmalik@redhat.com>
+Date: Tue, 6 Feb 2024 13:46:10 +0100
+Subject: [PATCH 2/2] tools/resolve_btfids: Fix cross-compilation to non-host
+ endianness
+
+The .BTF_ids section is pre-filled with zeroed BTF ID entries during the
+build and afterwards patched by resolve_btfids with correct values.
+Since resolve_btfids always writes in host-native endianness, it relies
+on libelf to do the translation when the target ELF is cross-compiled to
+a different endianness (this was introduced in commit 61e8aeda9398
+("bpf: Fix libelf endian handling in resolv_btfids")).
+
+Unfortunately, the translation will corrupt the flags fields of SET8
+entries because these were written during vmlinux compilation and are in
+the correct endianness already. This will lead to numerous selftests
+failures such as:
+
+    $ sudo ./test_verifier 502 502
+    #502/p sleepable fentry accept FAIL
+    Failed to load prog 'Invalid argument'!
+    bpf_fentry_test1 is not sleepable
+    verification time 34 usec
+    stack depth 0
+    processed 0 insns (limit 1000000) max_states_per_insn 0 total_states 0 peak_states 0 mark_read 0
+    Summary: 0 PASSED, 0 SKIPPED, 1 FAILED
+
+Since it's not possible to instruct libelf to translate just certain
+values, let's manually bswap the flags (both global and entry flags) in
+resolve_btfids when needed, so that libelf then translates everything
+correctly.
+
+Fixes: ef2c6f370a63 ("tools/resolve_btfids: Add support for 8-byte BTF sets")
+Signed-off-by: Viktor Malik <vmalik@redhat.com>
+Signed-off-by: Andrii Nakryiko <andrii@kernel.org>
+Link: https://lore.kernel.org/bpf/7b6bff690919555574ce0f13d2a5996cacf7bf69.1707223196.git.vmalik@redhat.com
+---
+ tools/bpf/resolve_btfids/main.c | 35 +++++++++++++++++++++++++++++++++
+ 1 file changed, 35 insertions(+)
+
+diff --git a/tools/bpf/resolve_btfids/main.c b/tools/bpf/resolve_btfids/main.c
+index 32634f00abba..d9520cb826b3 100644
+--- a/tools/bpf/resolve_btfids/main.c
++++ b/tools/bpf/resolve_btfids/main.c
+@@ -90,6 +90,14 @@
+ 
+ #define ADDR_CNT	100
+ 
++#if __BYTE_ORDER == __LITTLE_ENDIAN
++# define ELFDATANATIVE	ELFDATA2LSB
++#elif __BYTE_ORDER == __BIG_ENDIAN
++# define ELFDATANATIVE	ELFDATA2MSB
++#else
++# error "Unknown machine endianness!"
++#endif
++
+ struct btf_id {
+ 	struct rb_node	 rb_node;
+ 	char		*name;
+@@ -117,6 +125,7 @@ struct object {
+ 		int		 idlist_shndx;
+ 		size_t		 strtabidx;
+ 		unsigned long	 idlist_addr;
++		int		 encoding;
+ 	} efile;
+ 
+ 	struct rb_root	sets;
+@@ -320,6 +329,7 @@ static int elf_collect(struct object *obj)
+ {
+ 	Elf_Scn *scn = NULL;
+ 	size_t shdrstrndx;
++	GElf_Ehdr ehdr;
+ 	int idx = 0;
+ 	Elf *elf;
+ 	int fd;
+@@ -351,6 +361,13 @@ static int elf_collect(struct object *obj)
+ 		return -1;
+ 	}
+ 
++	if (gelf_getehdr(obj->efile.elf, &ehdr) == NULL) {
++		pr_err("FAILED cannot get ELF header: %s\n",
++			elf_errmsg(-1));
++		return -1;
++	}
++	obj->efile.encoding = ehdr.e_ident[EI_DATA];
++
+ 	/*
+ 	 * Scan all the elf sections and look for save data
+ 	 * from .BTF_ids section and symbols.
+@@ -681,6 +698,24 @@ static int sets_patch(struct object *obj)
+ 			 */
+ 			BUILD_BUG_ON(set8->pairs != &set8->pairs[0].id);
+ 			qsort(set8->pairs, set8->cnt, sizeof(set8->pairs[0]), cmp_id);
++
++			/*
++			 * When ELF endianness does not match endianness of the
++			 * host, libelf will do the translation when updating
++			 * the ELF. This, however, corrupts SET8 flags which are
++			 * already in the target endianness. So, let's bswap
++			 * them to the host endianness and libelf will then
++			 * correctly translate everything.
++			 */
++			if (obj->efile.encoding != ELFDATANATIVE) {
++				int i;
++
++				set8->flags = bswap_32(set8->flags);
++				for (i = 0; i < set8->cnt; i++) {
++					set8->pairs[i].flags =
++						bswap_32(set8->pairs[i].flags);
++				}
++			}
+ 		}
+ 
+ 		pr_debug("sorting  addr %5lu: cnt %6d [%s]\n",
+-- 
+2.39.3
+

--- a/ci/diffs/0099-selftest-cross-compile.diff
+++ b/ci/diffs/0099-selftest-cross-compile.diff
@@ -1,14 +1,13 @@
 diff --git a/tools/testing/selftests/bpf/Makefile b/tools/testing/selftests/bpf/Makefile
-index a38a3001527c..a403a9d5c529 100644
+index a38a3001527c..af68528cc944 100644
 --- a/tools/testing/selftests/bpf/Makefile
 +++ b/tools/testing/selftests/bpf/Makefile
-@@ -171,7 +171,8 @@ INCLUDE_DIR := $(SCRATCH_DIR)/include
- BPFOBJ := $(BUILD_DIR)/libbpf/libbpf.a
- ifneq ($(CROSS_COMPILE),)
- HOST_BUILD_DIR		:= $(BUILD_DIR)/host
--HOST_SCRATCH_DIR	:= $(OUTPUT)/host-tools
-+#HOST_SCRATCH_DIR	:= $(OUTPUT)/host-tools
-+HOST_SCRATCH_DIR	:= $(SCRATCH_DIR)
- HOST_INCLUDE_DIR	:= $(HOST_SCRATCH_DIR)/include
- else
- HOST_BUILD_DIR		:= $(BUILD_DIR)
+@@ -304,7 +304,7 @@ $(OUTPUT)/test_maps: $(TESTING_HELPERS)
+ $(OUTPUT)/test_verifier: $(TESTING_HELPERS) $(CAP_HELPERS) $(UNPRIV_HELPERS)
+ $(OUTPUT)/xsk.o: $(BPFOBJ)
+ 
+-BPFTOOL ?= $(DEFAULT_BPFTOOL)
++BPFTOOL ?= $(TRUNNER_BPFTOOL)
+ $(DEFAULT_BPFTOOL): $(wildcard $(BPFTOOLDIR)/*.[ch] $(BPFTOOLDIR)/Makefile)    \
+ 		    $(HOST_BPFOBJ) | $(HOST_BUILD_DIR)/bpftool
+ 	$(Q)$(MAKE) $(submake_extras)  -C $(BPFTOOLDIR)			       \


### PR DESCRIPTION
The original patch caused a race condition where 2 rules tried to write to the same files (host-tools and (target) tools directory) causing errors similar to the ones below.

Instead of changing what the scratch dir is, this new patch sets `BPFTOOL` to default to
`TRUNNER_BPFTOOL` instead of `DEFAUlT_BPFTOOL`.

```
2024-02-14T19:49:54.6430105Z   MKDIR
2024-02-14T19:49:54.6547753Z   GEN     /tmp/work/bpf/bpf/tools/testing/selftests/bpf/bpf-helpers.rst
2024-02-14T19:49:54.6552447Z   GEN     /tmp/work/bpf/bpf/tools/testing/selftests/bpf/bpf-syscall.rst
2024-02-14T19:49:54.6698129Z   GEN     /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/build/host/libbpf/bpf_helper_defs.h
2024-02-14T19:49:54.6699474Z   GEN     /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/build/libbpf/bpf_helper_defs.h
2024-02-14T19:49:54.6700946Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools//include/bpf/bpf.h
2024-02-14T19:49:54.6702035Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/include/bpf/bpf.h
2024-02-14T19:49:54.6703060Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools//include/bpf/libbpf.h
2024-02-14T19:49:54.6705068Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/include/bpf/libbpf.h
2024-02-14T19:49:54.6706136Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools//include/bpf/btf.h
2024-02-14T19:49:54.6707103Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/include/bpf/btf.h
2024-02-14T19:49:54.6708613Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools//include/bpf/libbpf_common.h
2024-02-14T19:49:54.6709705Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools//include/bpf/libbpf_legacy.h
2024-02-14T19:49:54.6710767Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/include/bpf/libbpf_common.h
2024-02-14T19:49:54.6711833Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/include/bpf/libbpf_legacy.h
2024-02-14T19:49:54.6712886Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools//include/bpf/bpf_helpers.h
2024-02-14T19:49:54.6713934Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools//include/bpf/bpf_tracing.h
2024-02-14T19:49:54.6715873Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/include/bpf/bpf_helpers.h
2024-02-14T19:49:54.6717899Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools//include/bpf/bpf_endian.h
2024-02-14T19:49:54.6719951Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/include/bpf/bpf_tracing.h
2024-02-14T19:49:54.6722146Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools//include/bpf/bpf_core_read.h
2024-02-14T19:49:54.6724480Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools//include/bpf/skel_internal.h
2024-02-14T19:49:54.6726350Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/include/bpf/bpf_endian.h
2024-02-14T19:49:54.6728299Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools//include/bpf/libbpf_version.h
2024-02-14T19:49:54.6730306Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools//include/bpf/usdt.bpf.h
2024-02-14T19:49:54.6732346Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/include/bpf/bpf_core_read.h
2024-02-14T19:49:54.6733964Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/include/bpf/skel_internal.h
2024-02-14T19:49:54.6735555Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/include/bpf/libbpf_version.h
2024-02-14T19:49:54.6746662Z install: cannot change permissions of '/tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/include/bpf/bpf.h': No such file or directory
2024-02-14T19:49:54.6749334Z make[1]: *** [Makefile:250: /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/include/bpf/bpf.h] Error 1
2024-02-14T19:49:54.6750682Z make[1]: *** Deleting file '/tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/include/bpf/bpf.h'
2024-02-14T19:49:54.6751477Z make[1]: *** Waiting for unfinished jobs....
2024-02-14T19:49:54.6752760Z install: cannot create regular file '/tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/include/bpf/libbpf_common.h': File exists
2024-02-14T19:49:54.6754094Z   INSTALL /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/include/bpf/usdt.bpf.h
2024-02-14T19:49:54.6755332Z make[1]: *** [Makefile:250: /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/include/bpf/libbpf_common.h] Error 1
2024-02-14T19:49:54.6756783Z make[1]: *** Deleting file '/tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/include/bpf/libbpf_common.h'
2024-02-14T19:49:54.6823593Z   HOSTCC  /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/build/host/libbpf/fixdep.o
2024-02-14T19:49:54.6824781Z   HOSTCC  /tmp/work/bpf/bpf/tools/testing/selftests/bpf/tools/build/libbpf/fixdep.o
```