### PR TITLE
ci: Disable lockdep for s390x

### DIFF
--- a/ci/diffs/0099-s390x_nolockdep.diff
+++ b/ci/diffs/0099-s390x_nolockdep.diff
@@ -1,0 +1,48 @@
+From 470d0c7874ac638ea62cddc3a20ec047fa4ab539 Mon Sep 17 00:00:00 2001
+From: Manu Bretelle <chantr4@gmail.com>
+Date: Wed, 14 Feb 2024 17:25:35 -0800
+Subject: [PATCH] bpf/selftests: disable lockdep on s390x
+
+Tests are slow to run on s390x, this should make them faster.
+
+Signed-off-by: Manu Bretelle <chantr4@gmail.com>
+---
+ tools/testing/selftests/bpf/config.s390x | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/tools/testing/selftests/bpf/config.s390x b/tools/testing/selftests/bpf/config.s390x
+index 706931a8c2c69..67bfd62b0b582 100644
+--- a/tools/testing/selftests/bpf/config.s390x
++++ b/tools/testing/selftests/bpf/config.s390x
+@@ -23,11 +23,11 @@ CONFIG_CPUSETS=y
+ CONFIG_CRASH_DUMP=y
+ CONFIG_CRYPTO_USER_API_RNG=y
+ CONFIG_CRYPTO_USER_API_SKCIPHER=y
+-CONFIG_DEBUG_ATOMIC_SLEEP=y
++CONFIG_DEBUG_ATOMIC_SLEEP=n
+ CONFIG_DEBUG_INFO_BTF=y
+ CONFIG_DEBUG_INFO_DWARF4=y
+ CONFIG_DEBUG_LIST=y
+-CONFIG_DEBUG_LOCKDEP=y
++CONFIG_DEBUG_LOCKDEP=n
+ CONFIG_DEBUG_NOTIFIERS=y
+ CONFIG_DEBUG_PAGEALLOC=y
+ CONFIG_DEBUG_SECTION_MISMATCH=y
+@@ -71,7 +71,7 @@ CONFIG_KRETPROBES=y
+ CONFIG_KSM=y
+ CONFIG_LATENCYTOP=y
+ CONFIG_LIVEPATCH=y
+-CONFIG_LOCK_STAT=y
++CONFIG_LOCK_STAT=n
+ CONFIG_MACVLAN=y
+ CONFIG_MACVTAP=y
+ CONFIG_MAGIC_SYSRQ=y
+@@ -101,7 +101,7 @@ CONFIG_PCI=y
+ CONFIG_POSIX_MQUEUE=y
+ CONFIG_PROC_KCORE=y
+ CONFIG_PROFILING=y
+-CONFIG_PROVE_LOCKING=y
++CONFIG_PROVE_LOCKING=n
+ CONFIG_PTDUMP_DEBUGFS=y
+ CONFIG_RC_DEVICES=y
+ CONFIG_RC_LOOPBACK=y


### PR DESCRIPTION
 s390x's test_map runs slowly in CI due to the different layers of
hypervisors involved.

CI historical data shows that `test_maps` CI job for s390x, over the last 2 weeks, ran in:

  mean: 3010s
  p50: 2860s
  p90: 4140s
  p95: 4720s
  p99: 5580s

Ilya suggested disabling lockdep based on flamegraph.

Testing in [0] brought down the run time to 516s. Other tests do not seem to benefit/regress.

While this will disminish the value of test_maps for s390x, we still have lockdep coverage for others architectures.

[0]
https://github.com/kernel-patches/bpf/actions/runs/7909828985/job/21591624824

Suggested-by: Ilya Leoshkevich <iii@linux.ibm.com>