### PR TITLE
denylist: add xdp_bonding/xdp_bonding_features to DENYLIST.

### DIFF
--- a/ci/vmtest/configs/DENYLIST
+++ b/ci/vmtest/configs/DENYLIST
@@ -8,3 +8,4 @@ test_ima	# All of CI is broken on it following 6.3-rc1 merge
 
 lwt_reroute      # crashes kernel after netnext merge from 2ab1efad60ad "net/sched: cls_api: complement tcf_tfilter_dump_policy"
 tc_links_ingress # started failing after net-next merge from 2ab1efad60ad "net/sched: cls_api: complement tcf_tfilter_dump_policy"
+xdp_bonding/xdp_bonding_features     # started failing after net merge from 359e54a93ab4 "l2tp: pass correct message length to ip6_append_data"


### PR DESCRIPTION
xdp_bonding/xdp_bonding_features causes bpf-ci fail after net merge.