### PR TITLE
ci: disavle ipv6 version of the flaky migrate_reuseport subtest

### DIFF
--- a/ci/vmtest/configs/DENYLIST
+++ b/ci/vmtest/configs/DENYLIST
@@ -11,3 +11,4 @@ tc_links_ingress # started failing after net-next merge from 2ab1efad60ad "net/s
 xdp_bonding/xdp_bonding_features     # started failing after net merge from 359e54a93ab4 "l2tp: pass correct message length to ip6_append_data"
 tc_redirect/tc_redirect_dtime # uapi breakage after net-next commit 885c36e59f46 ("net: Re-use and set mono_delivery_time bit for userspace tstamp packets")
 migrate_reuseport/IPv4 TCP_NEW_SYN_RECV reqsk_timer_handler # flaky, under investigation
+migrate_reuseport/IPv6 TCP_NEW_SYN_RECV reqsk_timer_handler # flaky, under investigation


### PR DESCRIPTION
We already disabled ipv4 version, ipv6 is equally flaky, let's disable both.