### PR TITLE
ci: build: Make -O2 build name a 3-tuple as well

### DIFF
--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -41,7 +41,7 @@ on:
 
 jobs:
   build:
-    name: build for ${{ inputs.arch }} with ${{ inputs.toolchain_full }}${{ inputs.release && ' and -O2 optimization' || '' }}
+    name: build for ${{ inputs.arch }} with ${{ inputs.toolchain_full }}${{ inputs.release && '-O2' || '' }}
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: 100
     env:


### PR DESCRIPTION
All other job names are in 'X for Y with Z' form. Normalize the build job name to that form as well for easier parsing.