### PR TITLE
pahole: pin to c2f89dab3f2b0ebb53bab3ed8be32f41cb743c37

### DIFF
--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -93,6 +93,7 @@ jobs:
         with:
           arch: ${{ inputs.arch }}
           llvm-version: ${{ inputs.llvm-version }}
+          pahole: c2f89dab3f2b0ebb53bab3ed8be32f41cb743c37
       - name: Build kernel image
         uses: libbpf/ci/build-linux@main
         with:


### PR DESCRIPTION
s390x is failing due to a pahole change, pin to c2f89dab3f2b0ebb53bab3ed8be32f41cb743c37 to get CI back on track