### PR TITLE
workflow: Also run the workflow against bpf-net_base and for-next_base

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - bpf_base
       - bpf-next_base
+      - bpf-net_base
+      - for-next_base
 
 concurrency:
   group: ci-test-${{ github.ref_name }}


### PR DESCRIPTION
We have added those 2 branches to be tracked. For CI to run when those get updated, we need to add them to the list of branches to track.