### PR TITLE
Add uprobe_multi_test/consumers to DENYLIST

### DIFF
--- a/ci/vmtest/configs/DENYLIST
+++ b/ci/vmtest/configs/DENYLIST
@@ -5,6 +5,7 @@ core_reloc/enum64val
 core_reloc/size___diff_sz
 core_reloc/type_based___diff_sz
 test_ima	# All of CI is broken on it following 6.3-rc1 merge
+uprobe_multi_test/consumers # CI is broken since 440b65232829
 
 lwt_reroute      # crashes kernel after netnext merge from 2ab1efad60ad "net/sched: cls_api: complement tcf_tfilter_dump_policy"
 tc_links_ingress # started failing after net-next merge from 2ab1efad60ad "net/sched: cls_api: complement tcf_tfilter_dump_policy"


### PR DESCRIPTION
This test fails on bpf-next_base, which breaks the CI.

Patch when the test was added: https://lore.kernel.org/bpf/20240722202758.3889061-1-jolsa@kernel.org/T/#u
Broken since: [440b65232829](https://github.com/kernel-patches/bpf/commit/440b65232829fad69947b8de983c13a525cc8871)

cc: @chantra 