### PR TITLE
add BPF GCC support for BPF CI

### DIFF
--- a/.github/workflows/kernel-build-test.yml
+++ b/.github/workflows/kernel-build-test.yml
@@ -15,6 +15,10 @@ on:
         required: true
         type: string
         description: The toolchain, e.g gcc, llvm
+      bpf-toolchain:
+        required: true
+        type: string
+        description: The toolchain, e.g gcc, llvm
       runs_on:
         required: true
         type: string
@@ -65,6 +69,7 @@ jobs:
       arch: ${{ inputs.arch }}
       toolchain_full: ${{ inputs.toolchain_full }}
       toolchain: ${{ inputs.toolchain }}
+      bpf-toolchain: ${{ inputs.bpf-toolchain }}
       runs_on: ${{ inputs.build_runs_on }}
       llvm-version: ${{ inputs.llvm-version }}
       kernel: ${{ inputs.kernel }}
@@ -76,6 +81,7 @@ jobs:
       arch: ${{ inputs.arch }}
       toolchain_full: ${{ inputs.toolchain_full }}
       toolchain: ${{ inputs.toolchain }}
+      bpf-toolchain: ${{ inputs.bpf-toolchain }}
       runs_on: ${{ inputs.runs_on }}
       llvm-version: ${{ inputs.llvm-version }}
       kernel: ${{ inputs.kernel }}

--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -16,6 +16,10 @@ on:
         required: true
         type: string
         description: The toolchain, e.g gcc, llvm
+      bpf-toolchain:
+        required: true
+        type: string
+        description: The toolchain, e.g gcc, llvm
       runs_on:
         required: true
         type: string
@@ -94,6 +98,7 @@ jobs:
           arch: ${{ inputs.arch }}
           llvm-version: ${{ inputs.llvm-version }}
           pahole: c2f89dab3f2b0ebb53bab3ed8be32f41cb743c37
+          bpf-toolchain: ${{ inputs.bpf-toolchain }}
       - name: Build kernel image
         uses: libbpf/ci/build-linux@main
         with:
@@ -107,6 +112,7 @@ jobs:
         with:
           arch: ${{ inputs.arch }}
           toolchain: ${{ inputs.toolchain }}
+          bpf-toolchain: ${{ inputs.bpf-toolchain }}
           kbuild-output: ${{ env.KBUILD_OUTPUT }}
           max-make-jobs: 32
           llvm-version: ${{ inputs.llvm-version }}
@@ -115,7 +121,7 @@ jobs:
           # RELEASE=0 adds -O0 make flag
           # RELEASE=1 adds -O2 make flag
           RELEASE: ${{ inputs.release && '1' || '' }}
-      - if: ${{ github.event_name != 'push' }}
+      - if: ${{ inputs.bpf-toolchain != 'gcc' && github.event_name != 'push' }}
         name: Build samples
         uses: libbpf/ci/build-samples@main
         with:
@@ -127,7 +133,7 @@ jobs:
       - name: Tar artifacts
         run: |
           bash .github/scripts/tar-artifact.sh ${{ inputs.arch }} ${{ inputs.toolchain_full }}
-      - if: ${{ github.event_name != 'push' }}
+      - if: ${{ inputs.bpf-toolchain != 'gcc' && github.event_name != 'push' }}
         name: Remove KBUILD_OUTPUT content
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
       arch: ${{ matrix.arch }}
       toolchain_full: ${{ matrix.toolchain.fullname }}
       toolchain: ${{ matrix.toolchain.name }}
+      bpf-toolchain: ${{ matrix.bpf_toolchain.name }}
       runs_on: ${{ toJSON(matrix.runs_on) }}
       build_runs_on: ${{ toJSON(matrix.build_runs_on) }}
       llvm-version: ${{ matrix.toolchain.version }}
@@ -50,7 +51,7 @@ jobs:
       tests: ${{ toJSON(matrix.tests) }}
       run_veristat: ${{ matrix.run_veristat }}
       # We only run tests on pull requests.
-      run_tests: ${{ github.event_name != 'push' }}
+      run_tests: ${{ matrix.bpf_toolchain.name != 'gcc' && github.event_name != 'push' }}
       # Download sources
       download_sources: ${{ github.repository == 'kernel-patches/vmtest' }}
       build_release: ${{ matrix.build_release }}


### PR DESCRIPTION
This pull requests enables BPF GCC compilation testing for the CI.

Required changes in libbpf/ci where pull requested in https://github.com/libbpf/ci/pull/144
Also previous PR was done in https://github.com/kernel-patches/bpf/pull/7737 and redirected there to this repo.