### PR TITLE
Revert "kernel-verstat: run veristat-meta on push events"

### DIFF
--- a/.github/workflows/kernel-veristat.yml
+++ b/.github/workflows/kernel-veristat.yml
@@ -88,7 +88,7 @@ jobs:
           baseline_name: ${{ env.ARCH_AND_TOOL}}-baseline-veristat-kernel
 
       - name: Compare and save veristat.meta.csv
-        if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: ./.github/actions/veristat_baseline_compare
         with:
           veristat_output: veristat-meta


### PR DESCRIPTION
Reverts kernel-patches/vmtest#313

A proper fix for veristat-meta requires more changes to the workflows. To be done.