### PR TITLE
veristat, kernel-test: fix vmlinuz search

### DIFF
--- a/.github/workflows/kernel-build-test.yml
+++ b/.github/workflows/kernel-build-test.yml
@@ -113,7 +113,8 @@ jobs:
       runs_on: ${{ inputs.runs_on }}
 
   veristat-meta:
-    if: ${{ inputs.run_veristat && github.repository_owner == 'kernel-patches' }}
+    # Check for vars.AWS_REGION is necessary to skip this job in case of a PR from a fork.
+    if: ${{ inputs.run_veristat && github.repository_owner == 'kernel-patches' && vars.AWS_REGION }}
     uses: ./.github/workflows/veristat-meta.yml
     needs: [build]
     permissions:

--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -147,7 +147,7 @@ jobs:
         uses: libbpf/ci/tar-artifacts@v2
         env:
           ARCHIVE_BPF_SELFTESTS: 'true'
-          ARCHIVE_MAKE_HELPERS: ${{ github.repository != 'kernel-patches/bpf' && 'true' || '' }}
+          ARCHIVE_MAKE_HELPERS: 'true'
           ARCHIVE_SCHED_EXT_SELFTESTS: ${{ env.BUILD_SCHED_EXT_SELFTESTS }}
         with:
           arch: ${{ inputs.arch }}

--- a/.github/workflows/kernel-test.yml
+++ b/.github/workflows/kernel-test.yml
@@ -50,6 +50,10 @@ jobs:
       DENYLIST_FILE: /tmp/denylist
     steps:
       - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github
+            ci
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
By using sparse checkout in kernel-test and veristat jobs we can save about 1.5 minute of runtime on each job. Job invoking libbpf/ci/run-vmtest action do not need access to the full kernel source tree.

However, this requires an adjustment to the list of the artifacts collected by kernel build. VMLINUZ might be search via `make image_name`, which requires makefiles and other scripts to be accessible.

Example of a failure:
https://github.com/kernel-patches/bpf/actions/runs/12204941090/job/34051427386

Set ARCHIVE_MAKE_HELPERS flag for libbpf/ci/tar-artifacts action to true in kernel-build.

Also, add check for vars.AWS_REGION before executing veristat-meta.