### PR TITLE
Re-enable sched_ext test

### DIFF
--- a/.github/scripts/matrix.py
+++ b/.github/scripts/matrix.py
@@ -98,8 +98,8 @@ class BuildConfig:
         if self.toolchain.version >= 18:
             tests_list.append("test_progs_cpuv4")
 
-        # if self.arch in [Arch.X86_64, Arch.AARCH64]:
-        #     tests_list.append("sched_ext")
+        if self.arch in [Arch.X86_64, Arch.AARCH64]:
+            tests_list.append("sched_ext")
 
         if not self.parallel_tests:
             tests_list = [test for test in tests_list if not test.endswith("parallel")]

--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -48,7 +48,7 @@ jobs:
         ARTIFACTS_ARCHIVE: "vmlinux-${{ inputs.arch }}-${{ inputs.toolchain_full }}.tar.zst"
         BPF_NEXT_BASE_BRANCH: 'master'
         BPF_NEXT_FETCH_DEPTH: 64 # A bit of history is needed to facilitate incremental builds
-        # BUILD_SCHED_EXT_SELFTESTS: ${{ inputs.arch == 'x86_64' || inputs.arch == 'aarch64' && 'true' || '' }}
+        BUILD_SCHED_EXT_SELFTESTS: ${{ inputs.arch == 'x86_64' || inputs.arch == 'aarch64' && 'true' || '' }}
         KBUILD_OUTPUT: ${{ github.workspace }}/kbuild-output
         KERNEL: ${{ inputs.kernel }}
         KERNEL_ROOT: ${{ github.workspace }}

--- a/ci/diffs/9998-sched_ext-Fix-invalid-irq-restore-in-scx_ops_bypass.patch
+++ b/ci/diffs/9998-sched_ext-Fix-invalid-irq-restore-in-scx_ops_bypass.patch
@@ -1,0 +1,56 @@
+From 10e1d78546b3dd4ea9d773c0b0257064a99211e9 Mon Sep 17 00:00:00 2001
+From: Tejun Heo <tj@kernel.org>
+Date: Wed, 11 Dec 2024 11:01:51 -1000
+Subject: [PATCH] sched_ext: Fix invalid irq restore in scx_ops_bypass()
+
+While adding outer irqsave/restore locking, 0e7ffff1b811 ("scx: Fix raciness
+in scx_ops_bypass()") forgot to convert an inner rq_unlock_irqrestore() to
+rq_unlock() which could re-enable IRQ prematurely leading to the following
+warning:
+
+  raw_local_irq_restore() called with IRQs enabled
+  WARNING: CPU: 1 PID: 96 at kernel/locking/irqflag-debug.c:10 warn_bogus_irq_restore+0x30/0x40
+  ...
+  Sched_ext: create_dsq (enabling)
+  pstate: 60400005 (nZCv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
+  pc : warn_bogus_irq_restore+0x30/0x40
+  lr : warn_bogus_irq_restore+0x30/0x40
+  ...
+  Call trace:
+   warn_bogus_irq_restore+0x30/0x40 (P)
+   warn_bogus_irq_restore+0x30/0x40 (L)
+   scx_ops_bypass+0x224/0x3b8
+   scx_ops_enable.isra.0+0x2c8/0xaa8
+   bpf_scx_reg+0x18/0x30
+  ...
+  irq event stamp: 33739
+  hardirqs last  enabled at (33739): [<ffff8000800b699c>] scx_ops_bypass+0x174/0x3b8
+  hardirqs last disabled at (33738): [<ffff800080d48ad4>] _raw_spin_lock_irqsave+0xb4/0xd8
+
+Drop the stray _irqrestore().
+
+Signed-off-by: Tejun Heo <tj@kernel.org>
+Reported-by: Ihor Solodrai <ihor.solodrai@pm.me>
+Link: http://lkml.kernel.org/r/qC39k3UsonrBYD_SmuxHnZIQLsuuccoCrkiqb_BT7DvH945A1_LZwE4g-5Pu9FcCtqZt4lY1HhIPi0homRuNWxkgo1rgP3bkxa0donw8kV4=@pm.me
+Fixes: 0e7ffff1b811 ("scx: Fix raciness in scx_ops_bypass()")
+Cc: stable@vger.kernel.org # v6.12
+---
+ kernel/sched/ext.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/sched/ext.c b/kernel/sched/ext.c
+index 7fff1d045477..98519e6d0dcd 100644
+--- a/kernel/sched/ext.c
++++ b/kernel/sched/ext.c
+@@ -4763,7 +4763,7 @@ static void scx_ops_bypass(bool bypass)
+ 		 * sees scx_rq_bypassing() before moving tasks to SCX.
+ 		 */
+ 		if (!scx_enabled()) {
+-			rq_unlock_irqrestore(rq, &rf);
++			rq_unlock(rq, &rf);
+ 			continue;
+ 		}
+ 
+-- 
+2.47.1
+

--- a/ci/diffs/9999-scx-Fix-maximal-BPF-selftest-prog.patch
+++ b/ci/diffs/9999-scx-Fix-maximal-BPF-selftest-prog.patch
@@ -1,0 +1,56 @@
+From 70414cacbe536a197d56f58a42f9563e5a01b8ec Mon Sep 17 00:00:00 2001
+From: David Vernet <void@manifault.com>
+Date: Mon, 9 Dec 2024 09:29:24 -0600
+Subject: [PATCH] scx: Fix maximal BPF selftest prog
+
+maximal.bpf.c is still dispatching to and consuming from SCX_DSQ_GLOBAL.
+Let's have it use its own DSQ to avoid any runtime errors.
+
+Signed-off-by: David Vernet <void@manifault.com>
+---
+ tools/testing/selftests/sched_ext/maximal.bpf.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/tools/testing/selftests/sched_ext/maximal.bpf.c b/tools/testing/selftests/sched_ext/maximal.bpf.c
+index 4c005fa71810..430f5e13bf55 100644
+--- a/tools/testing/selftests/sched_ext/maximal.bpf.c
++++ b/tools/testing/selftests/sched_ext/maximal.bpf.c
+@@ -12,6 +12,8 @@
+ 
+ char _license[] SEC("license") = "GPL";
+ 
++#define DSQ_ID 0
++
+ s32 BPF_STRUCT_OPS(maximal_select_cpu, struct task_struct *p, s32 prev_cpu,
+ 		   u64 wake_flags)
+ {
+@@ -20,7 +22,7 @@ s32 BPF_STRUCT_OPS(maximal_select_cpu, struct task_struct *p, s32 prev_cpu,
+ 
+ void BPF_STRUCT_OPS(maximal_enqueue, struct task_struct *p, u64 enq_flags)
+ {
+-	scx_bpf_dsq_insert(p, SCX_DSQ_GLOBAL, SCX_SLICE_DFL, enq_flags);
++	scx_bpf_dsq_insert(p, DSQ_ID, SCX_SLICE_DFL, enq_flags);
+ }
+ 
+ void BPF_STRUCT_OPS(maximal_dequeue, struct task_struct *p, u64 deq_flags)
+@@ -28,7 +30,7 @@ void BPF_STRUCT_OPS(maximal_dequeue, struct task_struct *p, u64 deq_flags)
+ 
+ void BPF_STRUCT_OPS(maximal_dispatch, s32 cpu, struct task_struct *prev)
+ {
+-	scx_bpf_dsq_move_to_local(SCX_DSQ_GLOBAL);
++	scx_bpf_dsq_move_to_local(DSQ_ID);
+ }
+ 
+ void BPF_STRUCT_OPS(maximal_runnable, struct task_struct *p, u64 enq_flags)
+@@ -123,7 +125,7 @@ void BPF_STRUCT_OPS(maximal_cgroup_set_weight, struct cgroup *cgrp, u32 weight)
+ 
+ s32 BPF_STRUCT_OPS_SLEEPABLE(maximal_init)
+ {
+-	return 0;
++	return scx_bpf_create_dsq(DSQ_ID, -1);
+ }
+ 
+ void BPF_STRUCT_OPS(maximal_exit, struct scx_exit_info *info)
+-- 
+2.47.1
+


### PR DESCRIPTION
Include an upstream patch for selftests/sched_ext

Link: https://lore.kernel.org/all/20241209152924.4508-1-void@manifault.com/