### PR TITLE
Disable test_progs-bpf_gcc

### DIFF
--- a/.github/scripts/matrix.py
+++ b/.github/scripts/matrix.py
@@ -101,8 +101,10 @@ class BuildConfig:
         # if self.arch in [Arch.X86_64, Arch.AARCH64]:
         #     tests_list.append("sched_ext")
 
-        if self.arch == Arch.X86_64:
-            tests_list.append("test_progs-bpf_gcc")
+        # Don't run GCC BPF runner, because too many tests are failing
+        # See: https://lore.kernel.org/bpf/87bjw6qpje.fsf@oracle.com/
+        # if self.arch == Arch.X86_64:
+        #    tests_list.append("test_progs-bpf_gcc")
 
         if not self.parallel_tests:
             tests_list = [test for test in tests_list if not test.endswith("parallel")]


### PR DESCRIPTION
Don't run GCC BPF runner, because too many tests are failing at this point.

See: https://lore.kernel.org/bpf/87bjw6qpje.fsf@oracle.com/