### PR TITLE
kernel-build: implement autoscaling

### DIFF
--- a/.github/scripts/tmpfsify-workspace.sh
+++ b/.github/scripts/tmpfsify-workspace.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -x -euo pipefail
+
+TMPFS_SIZE=20 # GB
+MEM_TOTAL=$(awk '/MemTotal/ {print int($2/1024)}' /proc/meminfo)
+
+# sanity check: total mem is at least double TMPFS_SIZE
+if [ $MEM_TOTAL -lt $(($TMPFS_SIZE*1024*2)) ]; then
+    echo "tmpfsify-workspace.sh: will not allocate tmpfs, total memory is too low (${MEM_TOTAL}MB)"
+    exit 0
+fi
+
+dir="$(basename "$GITHUB_WORKSPACE")"
+cd "$(dirname "$GITHUB_WORKSPACE")"
+mv "${dir}" "${dir}.backup"
+mkdir "${dir}"
+sudo mount -t tmpfs -o size=${TMPFS_SIZE}G tmpfs "${dir}"
+rsync -a "${dir}.backup/" "${dir}"
+cd -
+

--- a/.github/workflows/kernel-build-test.yml
+++ b/.github/workflows/kernel-build-test.yml
@@ -78,7 +78,7 @@ jobs:
       arch: ${{ inputs.arch }}
       toolchain_full: ${{ inputs.toolchain_full }}
       toolchain: ${{ inputs.toolchain }}
-      runs_on: ${{ inputs.runs_on }}
+      runs_on: ${{ inputs.build_runs_on }}
       llvm-version: ${{ inputs.llvm-version }}
       kernel: ${{ inputs.kernel }}
       download_sources: ${{ inputs.download_sources }}

--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -42,18 +42,26 @@ on:
 jobs:
   build:
     name: build for ${{ inputs.arch }} with ${{ inputs.toolchain_full }}${{ inputs.release && '-O2' || '' }}
-    runs-on: ${{ fromJSON(inputs.runs_on) }}
-    timeout-minutes: 100
+    # To run on CodeBuild, runs-on value must correspond to the AWS
+    # CodeBuild project associated with the kernel-patches webhook
+    runs-on: >-
+      ${{
+          github.repository_owner == 'kernel-patches'
+          && format('codebuild-bpf-ci-{0}-{1}', github.run_id, github.run_attempt)
+          || fromJSON(inputs.runs_on)
+      }}
     env:
         ARTIFACTS_ARCHIVE: "vmlinux-${{ inputs.arch }}-${{ inputs.toolchain_full }}.tar.zst"
         BPF_NEXT_BASE_BRANCH: 'master'
         BPF_NEXT_FETCH_DEPTH: 64 # A bit of history is needed to facilitate incremental builds
+        CROSS_COMPILE: ${{ inputs.arch != 'x86_64' && 'true' || '' }}
         # BUILD_SCHED_EXT_SELFTESTS: ${{ inputs.arch == 'x86_64' || inputs.arch == 'aarch64' && 'true' || '' }}
         KBUILD_OUTPUT: ${{ github.workspace }}/kbuild-output
         KERNEL: ${{ inputs.kernel }}
         KERNEL_ROOT: ${{ github.workspace }}
         REPO_PATH: ""
         REPO_ROOT: ${{ github.workspace }}
+        RUNNER_TYPE: ${{ github.repository_owner == 'kernel-patches' && 'codebuild' || 'default' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -97,6 +105,18 @@ jobs:
           arch: ${{ inputs.arch }}
           llvm-version: ${{ inputs.llvm-version }}
           pahole: master
+
+        # We have to setup qemu+binfmt in order to enable cross-compation of selftests.
+        # During selftests build, freshly built bpftool is executed.
+        # On self-hosted bare-metal hosts binfmt is pre-configured.
+      - if: ${{ env.RUNNER_TYPE == 'codebuild' && env.CROSS_COMPILE }}
+        name: Set up docker
+        uses: docker/setup-docker-action@v4
+      - if: ${{ env.RUNNER_TYPE == 'codebuild' && env.CROSS_COMPILE }}
+        name: Setup binfmt and qemu
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.0
 
       - name: Build kernel image
         uses: libbpf/ci/build-linux@v3

--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -66,6 +66,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: ${{ inputs.download_sources && 1 || env.BPF_NEXT_FETCH_DEPTH }}
+
+      - if: ${{ env.RUNNER_TYPE == 'codebuild' }}
+        shell: bash
+        run: .github/scripts/tmpfsify-workspace.sh
+
       - if: ${{ inputs.download_sources }}
         name: Download bpf-next tree
         env:


### PR DESCRIPTION
Run kernel build jobs on the runners provided by AWS CodeBuild
service: AWS-hosted environment running our custom docker container
[1] on demand.

This will help handling demand spikes, such as when upstream is merged
into kernel-patches/bpf and workflows are triggered for each pending
patch.

[1] https://github.com/kernel-patches/runner/blob/main/Dockerfile