### PR TITLE
kernel-test: set TEST_PROGS_WATCHDOG_TIMEOUT to 600 seconds

### DIFF
--- a/.github/workflows/kernel-test.yml
+++ b/.github/workflows/kernel-test.yml
@@ -76,7 +76,7 @@ jobs:
           KERNEL_TEST: ${{ inputs.test }}
           SELFTESTS_BPF: ${{ github.workspace }}/selftests/bpf
           VMTEST_CONFIGS: ${{ github.workspace }}/ci/vmtest/configs
-          TEST_PROGS_WATCHDOG_TIMEOUT: 300
+          TEST_PROGS_WATCHDOG_TIMEOUT: 600
         with:
           arch: ${{ inputs.arch }}
           vmlinuz: '${{ github.workspace }}/vmlinuz'


### PR DESCRIPTION
When s390x runners are too busy, test_progs pyperf tests might get killed by a watchdog. Examples:
* https://github.com/kernel-patches/bpf/actions/runs/13644682543/job/38141565931
* https://github.com/kernel-patches/bpf/actions/runs/13644708075/job/38141613357
* https://github.com/kernel-patches/bpf/actions/runs/13644714812/job/38141643246

Double the timeout value to avoid unnecessary workflow failures.