### PR TITLE
matrix.py: configure codebuild runners

### DIFF
--- a/.github/workflows/gcc-bpf.yml
+++ b/.github/workflows/gcc-bpf.yml
@@ -27,7 +27,7 @@ jobs:
     name: GCC BPF
     runs-on: >-
       ${{
-          github.repository_owner == 'kernel-patches'
+          contains(fromJSON(inputs.runs_on), 'codebuild')
           && format('codebuild-bpf-ci-{0}-{1}', github.run_id, github.run_attempt)
           || fromJSON(inputs.runs_on)
       }}

--- a/.github/workflows/kernel-build-test.yml
+++ b/.github/workflows/kernel-build-test.yml
@@ -137,7 +137,8 @@ jobs:
     uses: ./.github/workflows/gcc-bpf.yml
     needs: [build]
     with:
-      runs_on: ${{ inputs.runs_on }}
+      # GCC BPF does not need /dev/kvm, so use the "build" runners
+      runs_on: ${{ inputs.build_runs_on }}
       arch: ${{ inputs.arch }}
       llvm-version: ${{ inputs.llvm-version }}
       toolchain: ${{ inputs.toolchain }}

--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -44,9 +44,10 @@ jobs:
     name: build for ${{ inputs.arch }} with ${{ inputs.toolchain_full }}${{ inputs.release && '-O2' || '' }}
     # To run on CodeBuild, runs-on value must correspond to the AWS
     # CodeBuild project associated with the kernel-patches webhook
+    # However matrix.py passes just a 'codebuild' string
     runs-on: >-
       ${{
-          github.repository_owner == 'kernel-patches'
+          contains(fromJSON(inputs.runs_on), 'codebuild')
           && format('codebuild-bpf-ci-{0}-{1}', github.run_id, github.run_attempt)
           || fromJSON(inputs.runs_on)
       }}


### PR DESCRIPTION
Ondemand AWS CodeBuild runners only make sense for kernel-patches/bpf, as this is the main CI repository. In particular, there is no reason to use CodeBuild on bpf-rc.

Control this in the matrix.py script: set build_runs_on to "codebuild" for managed repositories.