### PR TITLE
veristat: include branch name in the cache key

### DIFF
--- a/.github/actions/veristat_baseline_compare/action.yml
+++ b/.github/actions/veristat_baseline_compare/action.yml
@@ -22,7 +22,7 @@ runs:
     - if: ${{ github.event_name == 'pull_request' }}
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.baseline_name }}
+        key: ${{ inputs.baseline_name }}-${{ github.base_ref }}
         restore-keys: |
           ${{ inputs.baseline_name }}-
         path: '${{ github.workspace }}/${{ inputs.baseline_name }}'
@@ -45,5 +45,5 @@ runs:
     - if: ${{ github.event_name == 'push' }}
       uses: actions/cache/save@v4
       with:
-        key: ${{ inputs.baseline_name }}-${{ github.run_id }}
+        key: ${{ inputs.baseline_name }}-${{ github.ref_name }}-${{ github.run_id }}
         path: '${{ github.workspace }}/${{ inputs.baseline_name }}'


### PR DESCRIPTION
This will allow to distinguish between bpf-next and other base branches.