### PR TITLE
Revert "kernel-test: enable traffic monitoring on x86_64"

### DIFF
--- a/.github/workflows/kernel-test.yml
+++ b/.github/workflows/kernel-test.yml
@@ -76,7 +76,6 @@ jobs:
           KERNEL_TEST: ${{ inputs.test }}
           SELFTESTS_BPF: ${{ github.workspace }}/selftests/bpf
           VMTEST_CONFIGS: ${{ github.workspace }}/ci/vmtest/configs
-          TEST_PROGS_TRAFFIC_MONITOR: ${{ inputs.arch == 'x86_64' && 'true' || '' }}
           TEST_PROGS_WATCHDOG_TIMEOUT: 600
         with:
           arch: ${{ inputs.arch }}
@@ -87,10 +86,3 @@ jobs:
           # Here we must use kbuild-output local to the repo, because
           # it was extracted from the artifacts.
           kbuild-output: ${{ env.REPO_ROOT }}/kbuild-output
-
-      - if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: tmon-logs-${{ inputs.arch }}-${{ inputs.toolchain_full }}-${{ inputs.test }}
-          if-no-files-found: ignore
-          path: /tmp/tmon_pcap/*


### PR DESCRIPTION
This reverts commit a9f85502a4a5912aeded7d0a8baa6c4a2596404d.

There are job failures with this feature on some branches:
* https://github.com/kernel-patches/bpf/actions/runs/14041586178/job/39313704017
* https://github.com/kernel-patches/bpf/actions/runs/14041589098/job/39313608979