### PR TITLE
set-matrix: smarter autoscaling

### DIFF
--- a/.github/scripts/matrix.py
+++ b/.github/scripts/matrix.py
@@ -3,9 +3,10 @@
 import os
 import dataclasses
 import json
+import requests
 
 from enum import Enum
-from typing import Any, Dict, List, Final, Set, Union
+from typing import Any, Dict, List, Final, Set, Union, Optional
 
 MANAGED_OWNER: Final[str] = "kernel-patches"
 MANAGED_REPOS: Final[Set[str]] = {
@@ -14,8 +15,10 @@ MANAGED_REPOS: Final[Set[str]] = {
 }
 
 DEFAULT_SELF_HOSTED_RUNNER_TAGS: Final[List[str]] = ["self-hosted", "docker-noble-main"]
-DEFAULT_RUNNER: Final[str] = "ubuntu-24.04"
+DEFAULT_GITHUB_HOSTED_RUNNER: Final[str] = "ubuntu-24.04"
 DEFAULT_LLVM_VERSION: Final[int] = 17
+
+RUNNERS_BUSY_THRESHOLD: Final[float] = 0.8
 
 
 class Arch(str, Enum):
@@ -58,6 +61,92 @@ class Toolchain:
         }
 
 
+def query_runners_from_github() -> List[Dict[str, Any]]:
+    if "GITHUB_TOKEN" not in os.environ:
+        return []
+    token = os.environ["GITHUB_TOKEN"]
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+    owner = os.environ["GITHUB_REPOSITORY_OWNER"]
+    url: Optional[str] = f"https://api.github.com/orgs/{owner}/actions/runners"
+    # GitHub returns 30 runners per page, fetch all
+    all_runners = []
+    try:
+        while url is not None:
+            response = requests.get(url, headers=headers)
+            if response.status_code != 200:
+                print(f"Failed to query runners: {response.status_code}")
+                print(f"response: {response.text}")
+                return []
+            data = response.json()
+            all_runners.extend(data.get("runners", []))
+            # Check for next page URL in Link header
+            url = None
+            if "Link" in response.headers:
+                links = requests.utils.parse_header_links(response.headers["Link"])
+                for link in links:
+                    if link["rel"] == "next":
+                        url = link["url"]
+                        break
+        return all_runners
+    except Exception as e:
+        print(f"Warning: Failed to query runner status due to exception: {e}")
+        return []
+
+
+all_runners_cached: Optional[List[Dict[str, Any]]] = None
+
+
+def all_runners() -> List[Dict[str, Any]]:
+    global all_runners_cached
+    if all_runners_cached is None:
+        print("Querying runners from GitHub...")
+        all_runners_cached = query_runners_from_github()
+        print(f"Github returned {len(all_runners_cached)} runners")
+        counts = count_by_status(all_runners_cached)
+        print(
+            f"Busy: {counts['busy']}, Idle: {counts['idle']}, Offline: {counts['offline']}"
+        )
+    return all_runners_cached
+
+
+def runner_labels(runner: Dict[str, Any]) -> List[str]:
+    return [label["name"] for label in runner["labels"]]
+
+
+def is_self_hosted_runner(runner: Dict[str, Any]) -> bool:
+    labels = runner_labels(runner)
+    for label in DEFAULT_SELF_HOSTED_RUNNER_TAGS:
+        if label not in labels:
+            return False
+    return True
+
+
+def self_hosted_runners() -> List[Dict[str, Any]]:
+    runners = all_runners()
+    return [r for r in runners if is_self_hosted_runner(r)]
+
+
+def runners_by_arch(arch: Arch) -> List[Dict[str, Any]]:
+    runners = self_hosted_runners()
+    return [r for r in runners if arch.value in runner_labels(r)]
+
+
+def count_by_status(runners: List[Dict[str, Any]]) -> Dict[str, int]:
+    result = {"busy": 0, "idle": 0, "offline": 0}
+    for runner in runners:
+        if runner["status"] == "online":
+            if runner["busy"]:
+                result["busy"] += 1
+            else:
+                result["idle"] += 1
+        else:
+            result["offline"] += 1
+    return result
+
+
 @dataclasses.dataclass
 class BuildConfig:
     arch: Arch
@@ -72,14 +161,28 @@ class BuildConfig:
         if is_managed_repo():
             return DEFAULT_SELF_HOSTED_RUNNER_TAGS + [self.arch.value]
         else:
-            return [DEFAULT_RUNNER]
+            return [DEFAULT_GITHUB_HOSTED_RUNNER]
 
     @property
     def build_runs_on(self) -> List[str]:
-        if is_managed_repo():
+        if not is_managed_repo():
+            return [DEFAULT_GITHUB_HOSTED_RUNNER]
+        # For managed repos, check the busyness of relevant self-hosted runners
+        # If they are too busy, use codebuild
+        runner_arch = self.arch
+        # We don't build s390x kernel on s390x runners, because it's too slow
+        # Cross-compiling on x86_64 is faster
+        if runner_arch == Arch.S390X:
+            runner_arch = Arch.X86_64
+        runners = runners_by_arch(runner_arch)
+        counts = count_by_status(runners)
+        online = counts["idle"] + counts["busy"]
+        busy = counts["busy"]
+        # if online <= 0, then something is wrong, don't use codebuild
+        if online > 0 and busy / online > RUNNERS_BUSY_THRESHOLD:
             return ["codebuild"]
         else:
-            return [DEFAULT_RUNNER]
+            return DEFAULT_SELF_HOSTED_RUNNER_TAGS + [runner_arch.value]
 
     @property
     def tests(self) -> Dict[str, Any]:

--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -62,7 +62,7 @@ jobs:
         KERNEL_ROOT: ${{ github.workspace }}
         REPO_PATH: ""
         REPO_ROOT: ${{ github.workspace }}
-        RUNNER_TYPE: ${{ github.repository_owner == 'kernel-patches' && 'codebuild' || 'default' }}
+        RUNNER_TYPE: ${{ contains(fromJSON(inputs.runs_on), 'codebuild') && 'codebuild' || 'default' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
     # This could be somehow fixed long term by making this action/workflow re-usable and letting the called
     # specify what to run on.
     runs-on: ${{ github.repository_owner == 'kernel-patches' && 'x86_64' || 'ubuntu-latest' }}
+    permissions: read-all
     outputs:
       build-matrix: ${{ steps.set-matrix-impl.outputs.build_matrix }}
     steps:
@@ -29,7 +30,14 @@ jobs:
           sparse-checkout: |
             .github
             ci
+      - name: Install script dependencies
+        shell: bash
+        run: |
+          sudo apt-get -y update
+          sudo apt-get -y install python3-requests
       - id: set-matrix-impl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_READ_RUNNERS }}
         run: |
           python3 .github/scripts/matrix.py
 


### PR DESCRIPTION
Currently we always run kernel builds on AWS CodeBuild, which autoscales on demand. However, we still have to maintain bare metal self-hosted runners in order to run selftests. If builds always run on CodeBuild, then the provisioned runners are underutilized.

Implement autoscaling logic in the set-matrix script:
* query github about the status of self-hosted runners
* if they are not busy, use them for builds
* otherwise use CodeBuild

The threshold is set at 80% of online suitable runners being busy.