### PR TITLE
set-matrix: disable codebuild runners when cross-compiling

### DIFF
--- a/.github/scripts/matrix.py
+++ b/.github/scripts/matrix.py
@@ -167,6 +167,14 @@ class BuildConfig:
     def build_runs_on(self) -> List[str]:
         if not is_managed_repo():
             return [DEFAULT_GITHUB_HOSTED_RUNNER]
+
+        # @Temporary: disable codebuild runners for cross-compilation jobs
+        match self.arch:
+            case Arch.S390X:
+                return DEFAULT_SELF_HOSTED_RUNNER_TAGS + [Arch.X86_64.value]
+            case Arch.AARCH64:
+                return DEFAULT_SELF_HOSTED_RUNNER_TAGS + [Arch.AARCH64.value]
+
         # For managed repos, check the busyness of relevant self-hosted runners
         # If they are too busy, use codebuild
         runner_arch = self.arch


### PR DESCRIPTION
On codebuild runners, kernel cross-compilation reliably fails with:

    /bin/sh: 1:
    /codebuild/output/src3696644155/src/actions-runner/_work/vmtest/vmtest/tools/testing/selftests/bpf/tools/sbin/bpftool:
    Exec format error

Examples:
* https://github.com/kernel-patches/bpf/actions/runs/14071382414/job/39407043081
* https://github.com/kernel-patches/bpf/actions/runs/14071415023/job/39406288267
* https://github.com/kernel-patches/vmtest/actions/runs/14072569194/job/39409645515

In comparison with recent successful runs, notable change on codebuild runners is the machine's kernel version:

    Kernel Version: 4.14.355-275.572.amzn2.x86_64
    Kernel Version: 6.1.129-138.220.amzn2023.x86_64

Needs further investigation.