### PR TITLE
Add res_spin_lock to DENYLIST.aarch64

### DIFF
--- a/ci/vmtest/configs/DENYLIST.aarch64
+++ b/ci/vmtest/configs/DENYLIST.aarch64
@@ -2,3 +2,4 @@ cgrp_local_storage                  # libbpf: prog 'update_cookie_tracing': fail
 core_reloc_btfgen                   # run_core_reloc_tests:FAIL:run_btfgen unexpected error: 32512 (errno 22)
 usdt/multispec                      # usdt_300_bad_attach unexpected pointer: 0x558c63d8f0
 xdp_bonding                         # whole test suite is very unstable on aarch64
+res_spin_lock                       # flaky


### PR DESCRIPTION
It's currently flaky:
* https://github.com/kernel-patches/bpf/actions/runs/14258309884
* https://github.com/kernel-patches/bpf/actions/runs/14258309884