### PR TITLE
s390x: switch to native builds temporarily

### DIFF
--- a/.github/scripts/matrix.py
+++ b/.github/scripts/matrix.py
@@ -171,7 +171,7 @@ class BuildConfig:
         # @Temporary: disable codebuild runners for cross-compilation jobs
         match self.arch:
             case Arch.S390X:
-                return DEFAULT_SELF_HOSTED_RUNNER_TAGS + [Arch.X86_64.value]
+                return DEFAULT_SELF_HOSTED_RUNNER_TAGS + [Arch.S390X.value]
             case Arch.AARCH64:
                 return DEFAULT_SELF_HOSTED_RUNNER_TAGS + [Arch.AARCH64.value]
 


### PR DESCRIPTION
Cross compilation is broken due to apt packages conflicts. Switch to native builds for now.

See: https://github.com/libbpf/ci/pull/179