### PR TITLE
Disable arena_spin_lock test everywhere

### DIFF
--- a/ci/vmtest/configs/DENYLIST
+++ b/ci/vmtest/configs/DENYLIST
@@ -14,3 +14,4 @@ migrate_reuseport/IPv6 TCP_NEW_SYN_RECV reqsk_timer_handler # flaky, under inves
 connect_force_port # unreliably fails
 sockmap_ktls/sockmap_ktls disconnect_after_delete* # https://lore.kernel.org/bpf/20250415163332.1836826-1-ihor.solodrai@linux.dev/
 verif_scale_pyperf600 # llvm 20 generates code that fails verification
+arena_spin_lock # llvm 20 generates code that fails verification

--- a/ci/vmtest/configs/DENYLIST.test_progs_cpuv4
+++ b/ci/vmtest/configs/DENYLIST.test_progs_cpuv4
@@ -1,2 +1,1 @@
-arena_spin_lock # llvm 20 generates code that fails verification
 verifier_arena/basic_alloc2


### PR DESCRIPTION
Turns out arena_spin_lock selftest built with LLVM 20 fails with configs other than cpuv4 runner:
* https://github.com/kernel-patches/bpf/actions/runs/14781515137/job/41501780952
* https://github.com/kernel-patches/bpf/actions/runs/14781517105/job/41501713788