### PR TITLE
veristat: use more strict restore key when fetching the baseline

### DIFF
--- a/.github/actions/veristat_baseline_compare/action.yml
+++ b/.github/actions/veristat_baseline_compare/action.yml
@@ -22,9 +22,9 @@ runs:
     - if: ${{ github.event_name == 'pull_request' }}
       uses: actions/cache/restore@v4
       with:
-        key: ${{ inputs.baseline_name }}-${{ github.base_ref }}
+        key: ${{ github.base_ref }}-${{ inputs.baseline_name }}-
         restore-keys: |
-          ${{ inputs.baseline_name }}-
+          ${{ github.base_ref }}-${{ inputs.baseline_name }}
         path: '${{ github.workspace }}/${{ inputs.baseline_name }}'
 
     - if: ${{ github.event_name == 'pull_request' }}
@@ -45,5 +45,5 @@ runs:
     - if: ${{ github.event_name == 'push' }}
       uses: actions/cache/save@v4
       with:
-        key: ${{ inputs.baseline_name }}-${{ github.ref_name }}-${{ github.run_id }}
+        key: ${{ github.ref_name }}-${{ inputs.baseline_name }}-${{ github.run_id }}
         path: '${{ github.workspace }}/${{ inputs.baseline_name }}'


### PR DESCRIPTION
There were CI failures caused by inappropriate cache restore, when bpf-next baseline was used for patch series against bpf-net. This happened because github cleaned up bpf-net baseline from the cache, and bpf-next baseline matched baseline_name prefix.

To avoid such collisions use `<base_branch>-<name>*` as the effective restore key. This is achieved by providing a fake exact key with trailing hyphen (which is always a miss), and relying on actions/cache matching a prefix from restore-keys list [1]. And the only restore-key we set is `<base_branch>-<name>`.

[1] https://github.com/actions/cache#creating-a-cache-key