### PR TITLE
ci/diffs: add patches with vmalloc fixes

### DIFF
--- a/ci/diffs/20250520-0001-mm-vmalloc-Actually-use-the-in-place-vrealloc-region.patch
+++ b/ci/diffs/20250520-0001-mm-vmalloc-Actually-use-the-in-place-vrealloc-region.patch
@@ -1,0 +1,33 @@
+From 0bb67681b72aa792751141567263cfa2d27a12ce Mon Sep 17 00:00:00 2001
+From: Kees Cook <kees@kernel.org>
+Date: Thu, 15 May 2025 14:42:15 -0700
+Subject: [PATCH 1/2] mm: vmalloc: Actually use the in-place vrealloc region
+
+The refactoring to not build a new vmalloc region only actually worked
+when shrinking. Actually return the resized area when it grows. Ugh.
+
+Reported-by: Shung-Hsi Yu <shung-hsi.yu@suse.com>
+Closes: https://lore.kernel.org/all/20250515-bpf-verifier-slowdown-vwo2meju4cgp2su5ckj@6gi6ssxbnfqg
+Tested-by: Eduard Zingerman <eddyz87@gmail.com>
+Tested-by: Pawan Gupta <pawan.kumar.gupta@linux.intel.com>
+Fixes: a0309faf1cb0 ("mm: vmalloc: support more granular vrealloc() sizing")
+Signed-off-by: Kees Cook <kees@kernel.org>
+---
+ mm/vmalloc.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/mm/vmalloc.c b/mm/vmalloc.c
+index 2d7511654831..74bd00fd734d 100644
+--- a/mm/vmalloc.c
++++ b/mm/vmalloc.c
+@@ -4111,6 +4111,7 @@ void *vrealloc_noprof(const void *p, size_t size, gfp_t flags)
+ 		if (want_init_on_alloc(flags))
+ 			memset((void *)p + old_size, 0, size - old_size);
+ 		vm->requested_size = size;
++		return (void *)p;
+ 	}
+ 
+ 	/* TODO: Grow the vm_area, i.e. allocate and map additional pages. */
+-- 
+2.47.1
+

--- a/ci/diffs/20250520-0002-mm-vmalloc-Only-zero-init-on-vrealloc-shrink.patch
+++ b/ci/diffs/20250520-0002-mm-vmalloc-Only-zero-init-on-vrealloc-shrink.patch
@@ -1,0 +1,49 @@
+From a71cfa01cb28c84db871af20ae18a58f7cb41382 Mon Sep 17 00:00:00 2001
+From: Kees Cook <kees@kernel.org>
+Date: Thu, 15 May 2025 14:42:16 -0700
+Subject: [PATCH 2/2] mm: vmalloc: Only zero-init on vrealloc shrink
+
+The common case is to grow reallocations, and since init_on_alloc will
+have already zeroed the whole allocation, we only need to zero when
+shrinking the allocation.
+
+Fixes: a0309faf1cb0 ("mm: vmalloc: support more granular vrealloc() sizing")
+Tested-by: Pawan Gupta <pawan.kumar.gupta@linux.intel.com>
+Signed-off-by: Kees Cook <kees@kernel.org>
+---
+ mm/vmalloc.c | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/mm/vmalloc.c b/mm/vmalloc.c
+index 74bd00fd734d..00cf1b575c89 100644
+--- a/mm/vmalloc.c
++++ b/mm/vmalloc.c
+@@ -4093,8 +4093,8 @@ void *vrealloc_noprof(const void *p, size_t size, gfp_t flags)
+ 	 * would be a good heuristic for when to shrink the vm_area?
+ 	 */
+ 	if (size <= old_size) {
+-		/* Zero out "freed" memory. */
+-		if (want_init_on_free())
++		/* Zero out "freed" memory, potentially for future realloc. */
++		if (want_init_on_free() || want_init_on_alloc(flags))
+ 			memset((void *)p + size, 0, old_size - size);
+ 		vm->requested_size = size;
+ 		kasan_poison_vmalloc(p + size, old_size - size);
+@@ -4107,9 +4107,11 @@ void *vrealloc_noprof(const void *p, size_t size, gfp_t flags)
+ 	if (size <= alloced_size) {
+ 		kasan_unpoison_vmalloc(p + old_size, size - old_size,
+ 				       KASAN_VMALLOC_PROT_NORMAL);
+-		/* Zero out "alloced" memory. */
+-		if (want_init_on_alloc(flags))
+-			memset((void *)p + old_size, 0, size - old_size);
++		/*
++		 * No need to zero memory here, as unused memory will have
++		 * already been zeroed at initial allocation time or during
++		 * realloc shrink time.
++		 */
+ 		vm->requested_size = size;
+ 		return (void *)p;
+ 	}
+-- 
+2.47.1
+


### PR DESCRIPTION
Recent mm patch [1] causes a regression in BPF verifier which leads to selftest failures. In particular verifier_loops1 test gets killed by the test_progs watchdog [2], although normally it passes in a few seconds.

This has been reported on the mailing list [3], and the fixes are in flight [4]. Add them as CI-specific patches for now.

[1] https://lore.kernel.org/all/20250424023119.work.333-kees@kernel.org
[2] https://github.com/kernel-patches/bpf/actions/runs/15144596086/job/42577510982
[3] https://lore.kernel.org/lkml/20250515-bpf-verifier-slowdown-vwo2meju4cgp2su5ckj@6gi6ssxbnfqg/
[4] https://lore.kernel.org/all/20250515214020.work.519-kees@kernel.org/