### PR TITLE
veristat-scx: specify a revision

### DIFF
--- a/.github/workflows/veristat-scx.yml
+++ b/.github/workflows/veristat-scx.yml
@@ -28,6 +28,7 @@ jobs:
       LLVM_VERSION: ${{ inputs.llvm_version }}
       SCX_BUILD_OUTPUT: ${{ github.workspace }}/scx-build-output
       SCX_PROGS: ${{ github.workspace }}/scx-progs
+      SCX_REVISION: e31fe903eae6e8fc407d68ec81b3effa2300923a
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
sched-ext build has been failing on current main:
* https://github.com/kernel-patches/bpf/actions/runs/15854824302
* https://github.com/kernel-patches/bpf/actions/runs/15841589202
* https://github.com/kernel-patches/bpf/actions/runs/15841590497

Specify a sched-ext repo revision to mitigate.