### PR TITLE
veristat-scx: pin scx to 59dd337 temporarily

### DIFF
--- a/.github/workflows/veristat-scx.yml
+++ b/.github/workflows/veristat-scx.yml
@@ -28,7 +28,7 @@ jobs:
       LLVM_VERSION: ${{ inputs.llvm_version }}
       SCX_BUILD_OUTPUT: ${{ github.workspace }}/scx-build-output
       SCX_PROGS: ${{ github.workspace }}/scx-progs
-      SCX_REVISION: main
+      SCX_REVISION: 59dd3371101324c13d023e9c414ad7125600c884
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Mitigate recent CI failures:
* https://github.com/kernel-patches/bpf/actions/runs/16354606452/job/46210448108
* https://github.com/kernel-patches/bpf/actions/runs/16356398031/job/46216284224