### PR TITLE
ci/diffs: add a ci patch for selftests build on for-next and bpf-net

### DIFF
--- a/ci/diffs/20251009-bpf-Finish-constification-of-1st-parameter-of-bpf_d_.patch
+++ b/ci/diffs/20251009-bpf-Finish-constification-of-1st-parameter-of-bpf_d_.patch
@@ -1,0 +1,80 @@
+From 92b389a828ec7e185e7777e491a057473f3214b6 Mon Sep 17 00:00:00 2001
+From: Rong Tao <rongtao@cestc.cn>
+Date: Sat, 4 Oct 2025 22:23:29 +0800
+Subject: [PATCH] bpf: Finish constification of 1st parameter of bpf_d_path()
+
+The commit 1b8abbb12128 ("bpf...d_path(): constify path argument")
+constified the first parameter of the bpf_d_path(), but failed to
+update it in all places. Finish constification.
+
+Otherwise the selftest fail to build:
+.../selftests/bpf/bpf_experimental.h:222:12: error: conflicting types for 'bpf_path_d_path'
+  222 | extern int bpf_path_d_path(const struct path *path, char *buf, size_t buf__sz) __ksym;
+      |            ^
+.../selftests/bpf/tools/include/vmlinux.h:153922:12: note: previous declaration is here
+ 153922 | extern int bpf_path_d_path(struct path *path, char *buf, size_t buf__sz) __weak __ksym;
+
+Fixes: 1b8abbb12128 ("bpf...d_path(): constify path argument")
+Signed-off-by: Rong Tao <rongtao@cestc.cn>
+Signed-off-by: Alexei Starovoitov <ast@kernel.org>
+---
+ include/uapi/linux/bpf.h                                | 2 +-
+ scripts/bpf_doc.py                                      | 1 +
+ tools/include/uapi/linux/bpf.h                          | 2 +-
+ tools/testing/selftests/bpf/progs/verifier_vfs_accept.c | 2 +-
+ 4 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/include/uapi/linux/bpf.h b/include/uapi/linux/bpf.h
+index ae83d8649ef1..6829936d33f5 100644
+--- a/include/uapi/linux/bpf.h
++++ b/include/uapi/linux/bpf.h
+@@ -4891,7 +4891,7 @@ union bpf_attr {
+  *
+  *		**-ENOENT** if the bpf_local_storage cannot be found.
+  *
+- * long bpf_d_path(struct path *path, char *buf, u32 sz)
++ * long bpf_d_path(const struct path *path, char *buf, u32 sz)
+  *	Description
+  *		Return full path for given **struct path** object, which
+  *		needs to be the kernel BTF *path* object. The path is
+diff --git a/scripts/bpf_doc.py b/scripts/bpf_doc.py
+index c77dc40f7689..15d113a1bc1d 100755
+--- a/scripts/bpf_doc.py
++++ b/scripts/bpf_doc.py
+@@ -788,6 +788,7 @@ class PrinterHelpersHeader(Printer):
+             'struct task_struct',
+             'struct cgroup',
+             'struct path',
++            'const struct path',
+             'struct btf_ptr',
+             'struct inode',
+             'struct socket',
+diff --git a/tools/include/uapi/linux/bpf.h b/tools/include/uapi/linux/bpf.h
+index ae83d8649ef1..6829936d33f5 100644
+--- a/tools/include/uapi/linux/bpf.h
++++ b/tools/include/uapi/linux/bpf.h
+@@ -4891,7 +4891,7 @@ union bpf_attr {
+  *
+  *		**-ENOENT** if the bpf_local_storage cannot be found.
+  *
+- * long bpf_d_path(struct path *path, char *buf, u32 sz)
++ * long bpf_d_path(const struct path *path, char *buf, u32 sz)
+  *	Description
+  *		Return full path for given **struct path** object, which
+  *		needs to be the kernel BTF *path* object. The path is
+diff --git a/tools/testing/selftests/bpf/progs/verifier_vfs_accept.c b/tools/testing/selftests/bpf/progs/verifier_vfs_accept.c
+index 3e2d76ee8050..55398c04290a 100644
+--- a/tools/testing/selftests/bpf/progs/verifier_vfs_accept.c
++++ b/tools/testing/selftests/bpf/progs/verifier_vfs_accept.c
+@@ -70,7 +70,7 @@ __success
+ int BPF_PROG(path_d_path_from_file_argument, struct file *file)
+ {
+ 	int ret;
+-	struct path *path;
++	const struct path *path;
+ 
+ 	/* The f_path member is a path which is embedded directly within a
+ 	 * file. Therefore, a pointer to such embedded members are still
+-- 
+2.47.3
+


### PR DESCRIPTION
Commit: https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/commit/?id=de7342228b7343774d6a9981c2ddbfb5e201044b