### PR TITLE
veristat-scx.yml: pin sched_ext to 737b9b1

### DIFF
--- a/.github/workflows/veristat-scx.yml
+++ b/.github/workflows/veristat-scx.yml
@@ -28,7 +28,7 @@ jobs:
       LLVM_VERSION: ${{ inputs.llvm_version }}
       SCX_BUILD_OUTPUT: ${{ github.workspace }}/scx-build-output
       SCX_PROGS: ${{ github.workspace }}/scx-progs
-      SCX_REVISION: main
+      SCX_REVISION: 737b9b13ccd15e44efb8cdba507f89e595ad3af6
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
sched_ext is moving away from meson [1], and this has broken our current "build sched_ext" workflow [2].

Pin to a working revision temporarily.

After build scripts are fixed, we can switch back to master.

[1] https://github.com/sched-ext/scx/discussions/2731
[2] https://github.com/kernel-patches/bpf/actions/runs/18725443519/job/53409557575