### PR TITLE
veristat-scx: update .bpf.o collection script

### DIFF
--- a/.github/scripts/collect-scx-bpf-progs.sh
+++ b/.github/scripts/collect-scx-bpf-progs.sh
@@ -6,8 +6,8 @@ PROGS_DIR=$1
 
 mkdir -p "${PROGS_DIR}"
 
-find "${SCX_BUILD_OUTPUT}" -type f -name "bpf.bpf.o" -print0 | \
+find "${SCX_BUILD_OUTPUT}" -type f -name "*.bpf.o" -printf '%P\0' | \
 while IFS= read -r -d '' prog; do
-    obj_name=$(echo "$prog" | grep -o "scx.*.bpf.o" | tr / _)
-    cp -v "$prog" "${PROGS_DIR}/${obj_name}"
+    obj_name=$(echo "${prog}" | tr / _)
+    cp -v "${SCX_BUILD_OUTPUT}/$prog" "${PROGS_DIR}/${obj_name}"
 done


### PR DESCRIPTION
sched_ext recently made changes to their build process, and there is a pending update of libbpf/ci/build-scx-scheds action [1].

Update script that collects .bpf.o objects from sched_ext build output to not miss any objects.

[1] https://github.com/libbpf/ci/pull/202