### PR TITLE
Revert "veristat-scx.yml: pin sched_ext to 737b9b1 (#410)"

### DIFF
--- a/.github/workflows/veristat-scx.yml
+++ b/.github/workflows/veristat-scx.yml
@@ -28,7 +28,7 @@ jobs:
       LLVM_VERSION: ${{ inputs.llvm_version }}
       SCX_BUILD_OUTPUT: ${{ github.workspace }}/scx-build-output
       SCX_PROGS: ${{ github.workspace }}/scx-progs
-      SCX_REVISION: 737b9b13ccd15e44efb8cdba507f89e595ad3af6
+      SCX_REVISION: main
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This reverts commit f2a40479ba94d71108e33328eb6e0dd4b04001b8.