### PR TITLE
veristat-scx: pin sched_ext to 5c4575195fe1

### DIFF
--- a/.github/workflows/veristat-scx.yml
+++ b/.github/workflows/veristat-scx.yml
@@ -28,7 +28,7 @@ jobs:
       LLVM_VERSION: ${{ inputs.llvm_version }}
       SCX_BUILD_OUTPUT: ${{ github.workspace }}/scx-build-output
       SCX_PROGS: ${{ github.workspace }}/scx-progs
-      SCX_REVISION: main
+      SCX_REVISION: 5c4575195fe1
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Rust schedulers fails to compile with the following error:

      3: In file included from src/bpf/main.bpf.c:9:
         src/bpf/scx_p2dq/main.bpf.c:1299:39: error: incompatible integer to pointer conversion passing 'u64' (aka 'unsigned long long') to parameter of type 'scx_task_common *' (aka '__attribute__((address_space(1))) struct scx_task_common *') [-Wint-conversion]

          1299 |                 ret = scx_atq_insert(pro->fifo.atq, (u64)p->pid);

Example of a failing CI job: https://github.com/kernel-patches/bpf/actions/runs/19352462628/job/55367279993?pr=10275#step:3:1347

Bisect points to 5c4575195fe1 as to a last known good revision.