### PR TITLE
DENYLIST.s390x: disable log_buf tests

### DIFF
--- a/ci/vmtest/configs/DENYLIST.s390x
+++ b/ci/vmtest/configs/DENYLIST.s390x
@@ -9,3 +9,4 @@ tailcalls
 trace_ext
 xdp_bpf2bpf
 xdp_metadata
+log_buf # fails with segfault, needs investigation


### PR DESCRIPTION
log_buf test appears to be causing a segfault on s390x

Temporarily disable the test to unblock CI.