### PR TITLE
DENYLIST.s390x: add tc_edt test

### DIFF
--- a/ci/vmtest/configs/DENYLIST.s390x
+++ b/ci/vmtest/configs/DENYLIST.s390x
@@ -10,3 +10,4 @@ trace_ext
 xdp_bpf2bpf
 xdp_metadata
 log_buf # fails with segfault, needs investigation
+tc_edt # flaky, needs investigation


### PR DESCRIPTION
tc_edt has been flaky on s390x, denylist it temporarily.

https://github.com/kernel-patches/bpf/actions/runs/19934400002/job/57155795600 https://github.com/kernel-patches/bpf/actions/runs/19917624631/job/57100737116