### PR TITLE
ai-code-review.yml: Allowlist KPD bots

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -123,6 +123,7 @@ jobs:
           github_token: ${{ steps.app-token.outputs.token }}
           use_bedrock: "true"
           claude_args: '--max-turns 100 --model us.anthropic.claude-opus-4-5-20251101-v1:0'
+          allowed_bots: "kernel-patches-daemon-bpf,kernel-patches-review-bot"
           prompt: |
             Current directory is the root of a Linux Kernel git repository.
 


### PR DESCRIPTION
Recent change in claude-code-action [1] fixed a bug, where checkHumanActor check was not performed.

This broke the AI code review workflows [2], because we unknowingly relied on the bug by not providing "allowed_bots" action parameter.

Fix this by specifying allowed bots.

[1] https://github.com/anthropics/claude-code-action/pull/826
[2] https://github.com/kernel-patches/bpf/actions/runs/21141584029/job/60796745476