### PR TITLE
veristat_compare.py: Reformat with black 26.1.0

### DIFF
--- a/.github/scripts/veristat_compare.py
+++ b/.github/scripts/veristat_compare.py
@@ -46,7 +46,6 @@ import enum
 from dataclasses import dataclass
 from typing import Dict, Iterable, List, Final
 
-
 TRESHOLD_PCT: Final[int] = 0
 
 SUMMARY_HEADERS = ["File", "Program", "Verdict", "States Diff (%)"]
@@ -57,16 +56,13 @@ TOTAL_STATES_DIFF_REGEX = (
 )
 
 
-TEXT_SUMMARY_TEMPLATE: Final[str] = (
-    """
+TEXT_SUMMARY_TEMPLATE: Final[str] = """
 # {title}
 
 {table}
 """.strip()
-)
 
-HTML_SUMMARY_TEMPLATE: Final[str] = (
-    """
+HTML_SUMMARY_TEMPLATE: Final[str] = """
 # {title}
 
 <details>
@@ -75,7 +71,6 @@ HTML_SUMMARY_TEMPLATE: Final[str] = (
 {table}
 </details>
 """.strip()
-)
 
 GITHUB_MARKUP_REPLACEMENTS: Final[Dict[str, str]] = {
     "->": "&rarr;",


### PR DESCRIPTION
Lint workflow started failing with newer black formatter.

Reformat with [1]:
    podman run --rm --volume $(pwd):/src --workdir /src pyfound/black:latest_release black .

[1] https://black.readthedocs.io/en/stable/usage_and_configuration/black_docker_image.html