### PR TITLE
ci/diffs: update recent temporary patches

### DIFF
--- a/ci/diffs/20260202-selftests-sched_ext-Fix-init_enable_count-flakiness.patch
+++ b/ci/diffs/20260202-selftests-sched_ext-Fix-init_enable_count-flakiness.patch
@@ -1,0 +1,105 @@
+From 4544e9c4ec9a5955a37fdd8204a3d98106f97ab7 Mon Sep 17 00:00:00 2001
+From: Tejun Heo <tj@kernel.org>
+Date: Mon, 2 Feb 2026 09:40:22 -1000
+Subject: [PATCH] selftests/sched_ext: Fix init_enable_count flakiness
+
+The init_enable_count test is flaky. The test forks 1024 children before
+attaching the scheduler to verify that existing tasks get ops.init_task()
+called. The children were using sleep(1) before exiting.
+
+7900aa699c34 ("sched_ext: Fix cgroup exit ordering by moving sched_ext_free()
+to finish_task_switch()") changed when tasks are removed from scx_tasks -
+previously when the task_struct was freed, now immediately in
+finish_task_switch() when the task dies.
+
+Before the commit, pre-forked children would linger on scx_tasks until freed
+regardless of when they exited, so the scheduler would always see them during
+iteration. The sleep(1) was unnecessary. After the commit, children are
+removed as soon as they die. The sleep(1) masks the problem in most cases but
+the test becomes flaky depending on timing.
+
+Fix by synchronizing properly using a pipe. All children block on read() and
+the parent signals them to exit by closing the write end after attaching the
+scheduler. The children are auto-reaped so there's no need to wait on them.
+
+Reported-by: Ihor Solodrai <ihor.solodrai@linux.dev>
+Cc: David Vernet <void@manifault.com>
+Cc: Andrea Righi <arighi@nvidia.com>
+Cc: Changwoo Min <changwoo@igalia.com>
+Cc: Emil Tsalapatis <emil@etsalapatis.com>
+Signed-off-by: Tejun Heo <tj@kernel.org>
+---
+ .../selftests/sched_ext/init_enable_count.c   | 34 +++++++++++++------
+ 1 file changed, 23 insertions(+), 11 deletions(-)
+
+diff --git a/tools/testing/selftests/sched_ext/init_enable_count.c b/tools/testing/selftests/sched_ext/init_enable_count.c
+index eddf9e0e26e7..82c71653977b 100644
+--- a/tools/testing/selftests/sched_ext/init_enable_count.c
++++ b/tools/testing/selftests/sched_ext/init_enable_count.c
+@@ -4,6 +4,7 @@
+  * Copyright (c) 2023 David Vernet <dvernet@meta.com>
+  * Copyright (c) 2023 Tejun Heo <tj@kernel.org>
+  */
++#include <signal.h>
+ #include <stdio.h>
+ #include <unistd.h>
+ #include <sched.h>
+@@ -23,6 +24,9 @@ static enum scx_test_status run_test(bool global)
+ 	int ret, i, status;
+ 	struct sched_param param = {};
+ 	pid_t pids[num_pre_forks];
++	int pipe_fds[2];
++
++	SCX_FAIL_IF(pipe(pipe_fds) < 0, "Failed to create pipe");
+ 
+ 	skel = init_enable_count__open();
+ 	SCX_FAIL_IF(!skel, "Failed to open");
+@@ -38,26 +42,34 @@ static enum scx_test_status run_test(bool global)
+ 	 * ensure (at least in practical terms) that there are more tasks that
+ 	 * transition from SCHED_OTHER -> SCHED_EXT than there are tasks that
+ 	 * take the fork() path either below or in other processes.
++	 *
++	 * All children will block on read() on the pipe until the parent closes
++	 * the write end after attaching the scheduler, which signals all of
++	 * them to exit simultaneously. Auto-reap so we don't have to wait on
++	 * them.
+ 	 */
++	signal(SIGCHLD, SIG_IGN);
+ 	for (i = 0; i < num_pre_forks; i++) {
+-		pids[i] = fork();
+-		SCX_FAIL_IF(pids[i] < 0, "Failed to fork child");
+-		if (pids[i] == 0) {
+-			sleep(1);
++		pid_t pid = fork();
++
++		SCX_FAIL_IF(pid < 0, "Failed to fork child");
++		if (pid == 0) {
++			char buf;
++
++			close(pipe_fds[1]);
++			read(pipe_fds[0], &buf, 1);
++			close(pipe_fds[0]);
+ 			exit(0);
+ 		}
+ 	}
++	close(pipe_fds[0]);
+ 
+ 	link = bpf_map__attach_struct_ops(skel->maps.init_enable_count_ops);
+ 	SCX_FAIL_IF(!link, "Failed to attach struct_ops");
+ 
+-	for (i = 0; i < num_pre_forks; i++) {
+-		SCX_FAIL_IF(waitpid(pids[i], &status, 0) != pids[i],
+-			    "Failed to wait for pre-forked child\n");
+-
+-		SCX_FAIL_IF(status != 0, "Pre-forked child %d exited with status %d\n", i,
+-			    status);
+-	}
++	/* Signal all pre-forked children to exit. */
++	close(pipe_fds[1]);
++	signal(SIGCHLD, SIG_DFL);
+ 
+ 	bpf_link__destroy(link);
+ 	SCX_GE(skel->bss->init_task_cnt, num_pre_forks);
+-- 
+2.52.0
+

--- a/ci/diffs/202602021-sched-mmcid-Prevent-live-lock-on-task-to-CPU-mo.patch
+++ b/ci/diffs/202602021-sched-mmcid-Prevent-live-lock-on-task-to-CPU-mo.patch
@@ -1,26 +1,26 @@
-From be0bb1ec8b6a13fda3a6f30ed5a94c88d64cf60d Mon Sep 17 00:00:00 2001
+From d6edf106f21e8be9edd79d5db40a14c78b307bf8 Mon Sep 17 00:00:00 2001
 From: Thomas Gleixner <tglx@kernel.org>
-Date: Thu, 29 Jan 2026 22:20:48 +0100
-Subject: [PATCH 202601291/202601294] sched/mmcid: Prevent live lock on task to
+Date: Mon, 2 Feb 2026 10:39:40 +0100
+Subject: [PATCH 202602021/202602024] sched/mmcid: Prevent live lock on task to
  CPU mode transition
 
 Ihor reported a BPF CI failure which turned out to be a live lock in the
 MM_CID management. The scenario is:
 
-A test program creates the 4th child, which means the MM_CID users become
+A test program creates the 5th thread, which means the MM_CID users become
 more than the number of CPUs (four in this example), so it switches to per
 CPU ownership mode.
 
 At this point each live task of the program has a CID associated. Assume
 thread creation order assignment for simplicity.
 
-   T0 (main thread)       CID0  runs fork() and creates T4
-   T1 (1st child)	  CID1
-   T2 (2nd child)	  CID2
-   T3 (3rd child)	  CID3
-   T4 (4th child)         ---   not visible yet
+   T0     CID0  runs fork() and creates T4
+   T1 	  CID1
+   T2 	  CID2
+   T3 	  CID3
+   T4       ---   not visible yet
 
-T0 sets mm_cid::percpu = true and transfers it's own CID to CPU0 where it
+T0 sets mm_cid::percpu = true and transfers its own CID to CPU0 where it
 runs on and then starts the fixup which walks through the threads to
 transfer the per task CIDs either to the CPU the task is running on or drop
 it back into the pool if the task is not on a CPU.
@@ -30,10 +30,10 @@ up with them. Going through all possible permutations with a python script
 revealed a few problematic cases. The most trivial one is:
 
    T1 schedules in on CPU1 and observes percpu == true, so it transfers
-      it's CID to CPU1
+      its CID to CPU1
 
-   T1 is migrated to CPU1 and schedule in observes percpu == true, but
-      CPU2 does not have a CID associated and T1 transferred it's own to
+   T1 is migrated to CPU2 and schedule in observes percpu == true, but
+      CPU2 does not have a CID associated and T1 transferred its own to
       CPU1
 
       So it has to allocate one with CPU2 runqueue lock held, but the
@@ -66,13 +66,14 @@ Fixes: fbd0e71dc370 ("sched/mmcid: Provide CID ownership mode fixup functions")
 Reported-by: Ihor Solodrai <ihor.solodrai@linux.dev>
 Signed-off-by: Thomas Gleixner <tglx@kernel.org>
 Closes: https://lore.kernel.org/2b7463d7-0f58-4e34-9775-6e2115cfb971@linux.dev
+Reviewed-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
 ---
- kernel/sched/core.c  | 118 ++++++++++++++++++++++++++++---------------
+ kernel/sched/core.c  | 128 ++++++++++++++++++++++++++++---------------
  kernel/sched/sched.h |   4 ++
- 2 files changed, 80 insertions(+), 42 deletions(-)
+ 2 files changed, 88 insertions(+), 44 deletions(-)
 
 diff --git a/kernel/sched/core.c b/kernel/sched/core.c
-index 60afadb6eede..bd86e4bd0cd7 100644
+index 60afadb6eede..f78966867d7b 100644
 --- a/kernel/sched/core.c
 +++ b/kernel/sched/core.c
 @@ -10265,7 +10265,8 @@ void call_trace_sched_update_nr_running(struct rq *rq, int count)
@@ -232,7 +233,7 @@ index 60afadb6eede..bd86e4bd0cd7 100644
  		pcp->cid = t->mm_cid.cid;
  	}
  }
-@@ -10505,9 +10537,9 @@ static bool mm_cid_fixup_task_to_cpu(struct task_struct *t, struct mm_struct *mm
+@@ -10505,18 +10537,17 @@ static bool mm_cid_fixup_task_to_cpu(struct task_struct *t, struct mm_struct *mm
  	if (!t->mm_cid.active)
  		return false;
  	if (cid_on_task(t->mm_cid.cid)) {
@@ -244,7 +245,33 @@ index 60afadb6eede..bd86e4bd0cd7 100644
  		else
  			mm_unset_cid_on_task(t);
  	}
-@@ -10592,11 +10624,13 @@ void sched_mm_cid_fork(struct task_struct *t)
+ 	return true;
+ }
+ 
+-static void mm_cid_fixup_tasks_to_cpus(void)
++static void mm_cid_do_fixup_tasks_to_cpus(struct mm_struct *mm)
+ {
+-	struct mm_struct *mm = current->mm;
+ 	struct task_struct *p, *t;
+ 	unsigned int users;
+ 
+@@ -10554,6 +10585,15 @@ static void mm_cid_fixup_tasks_to_cpus(void)
+ 	}
+ }
+ 
++static void mm_cid_fixup_tasks_to_cpus(void)
++{
++	struct mm_struct *mm = current->mm;
++
++	mm_cid_do_fixup_tasks_to_cpus(mm);
++	/* Clear the transition bit */
++	WRITE_ONCE(mm->mm_cid.transit, 0);
++}
++
+ static bool sched_mm_cid_add_user(struct task_struct *t, struct mm_struct *mm)
+ {
+ 	t->mm_cid.active = 1;
+@@ -10592,7 +10632,7 @@ void sched_mm_cid_fork(struct task_struct *t)
  		if (!percpu)
  			mm_cid_transit_to_task(current, pcp);
  		else
@@ -253,12 +280,6 @@ index 60afadb6eede..bd86e4bd0cd7 100644
  	}
  
  	if (percpu) {
- 		mm_cid_fixup_tasks_to_cpus();
-+		/* Clear the transition bit */
-+		WRITE_ONCE(mm->mm_cid.transit, 0);
- 	} else {
- 		mm_cid_fixup_cpus_to_tasks(mm);
- 		t->mm_cid.cid = mm_get_cid(mm);
 diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
 index d30cca6870f5..96f613d7d181 100644
 --- a/kernel/sched/sched.h

--- a/ci/diffs/202602022-sched-mmcid-Protect-transition-on-weakly-ordere.patch
+++ b/ci/diffs/202602022-sched-mmcid-Protect-transition-on-weakly-ordere.patch
@@ -1,7 +1,7 @@
-From e8d5b2118fbf73d72c1ddfdbf15909148b99069d Mon Sep 17 00:00:00 2001
+From 683cdd5667e8fc973ab52933deeb270a036bfa7a Mon Sep 17 00:00:00 2001
 From: Thomas Gleixner <tglx@kernel.org>
-Date: Thu, 29 Jan 2026 22:20:50 +0100
-Subject: [PATCH 202601292/202601294] sched/mmcid: Protect transition on weakly
+Date: Mon, 2 Feb 2026 10:39:45 +0100
+Subject: [PATCH 202602022/202602024] sched/mmcid: Protect transition on weakly
  ordered systems
 
 Shrikanth reported a hard lockup which he observed once. The stack trace
@@ -74,8 +74,11 @@ but that brings a memory barrier back into the scheduler hotpath, which was
 just designed out by the CID rewrite.
 
 That can be completely avoided by combining the per CPU mode and the
-transit storage into a single mm_cid::mode member. That makes the update of
-both states atomic and a concurrent read observes always consistent state.
+transit storage into a single mm_cid::mode member and ordering the stores
+against the fixup functions to prevent the CPU from reordering them.
+
+That makes the update of both states atomic and a concurrent read observes
+always consistent state.
 
 The price is an additional AND operation in mm_cid_schedin() to evaluate
 the per CPU or the per task path, but that's in the noise even on strongly
@@ -86,14 +89,15 @@ Fixes: fbd0e71dc370 ("sched/mmcid: Provide CID ownership mode fixup functions")
 Reported-by: Shrikanth Hegde <sshegde@linux.ibm.com>
 Signed-off-by: Thomas Gleixner <tglx@kernel.org>
 Closes: https://lore.kernel.org/bdfea828-4585-40e8-8835-247c6a8a76b0@linux.ibm.com
+Reviewed-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
 ---
- include/linux/rseq_types.h |  7 ++---
- kernel/sched/core.c        | 62 +++++++++++++++++++++++---------------
- kernel/sched/sched.h       | 21 +++++++------
- 3 files changed, 53 insertions(+), 37 deletions(-)
+ include/linux/rseq_types.h |  6 ++--
+ kernel/sched/core.c        | 66 +++++++++++++++++++++++++-------------
+ kernel/sched/sched.h       | 21 ++++++------
+ 3 files changed, 58 insertions(+), 35 deletions(-)
 
 diff --git a/include/linux/rseq_types.h b/include/linux/rseq_types.h
-index 332dc14b81c9..46e947cdf985 100644
+index 332dc14b81c9..ef0811379c54 100644
 --- a/include/linux/rseq_types.h
 +++ b/include/linux/rseq_types.h
 @@ -121,8 +121,7 @@ struct mm_cid_pcpu {
@@ -106,13 +110,7 @@ index 332dc14b81c9..46e947cdf985 100644
   * @max_cids:		The exclusive maximum CID value for allocation and convergence
   * @irq_work:		irq_work to handle the affinity mode change case
   * @work:		Regular work to handle the affinity mode change case
-@@ -134,13 +133,13 @@ struct mm_cid_pcpu {
-  *			as that is modified by mmget()/mm_put() by other entities which
-  *			do not actually share the MM.
-  * @pcpu_thrs:		Threshold for switching back from per CPU mode
-+ * @mode_change:	Mode change in progress
-  * @update_deferred:	A deferred switch back to per task mode is pending.
-  */
+@@ -139,8 +138,7 @@ struct mm_cid_pcpu {
  struct mm_mm_cid {
  	/* Hotpath read mostly members */
  	struct mm_cid_pcpu	__percpu *pcpu;
@@ -123,7 +121,7 @@ index 332dc14b81c9..46e947cdf985 100644
  
  	/* Rarely used. Moves @lock and @mutex into the second cacheline */
 diff --git a/kernel/sched/core.c b/kernel/sched/core.c
-index bd86e4bd0cd7..64999332076f 100644
+index f78966867d7b..f429ff4eb84c 100644
 --- a/kernel/sched/core.c
 +++ b/kernel/sched/core.c
 @@ -10293,16 +10293,25 @@ void call_trace_sched_update_nr_running(struct rq *rq, int count)
@@ -175,7 +173,7 @@ index bd86e4bd0cd7..64999332076f 100644
  		/* Enable per CPU mode when the number of users is above max_cids */
  		if (mc->users > mc->max_cids)
  			mc->pcpu_thrs = mm_cid_calc_pcpu_thrs(mc);
-@@ -10426,12 +10436,11 @@ static bool mm_update_max_cids(struct mm_struct *mm)
+@@ -10426,12 +10436,17 @@ static bool mm_update_max_cids(struct mm_struct *mm)
  	}
  
  	/* Mode change required? */
@@ -188,10 +186,16 @@ index bd86e4bd0cd7..64999332076f 100644
 -	WRITE_ONCE(mc->percpu, !!mc->pcpu_thrs);
 +	/* Flip the mode and set the transition flag to bridge the transfer */
 +	WRITE_ONCE(mc->mode, mc->mode ^ (MM_CID_TRANSIT | MM_CID_ONCPU));
++	/*
++	 * Order the store against the subsequent fixups so that
++	 * acquire(rq::lock) cannot be reordered by the CPU before the
++	 * store.
++	 */
++	smp_mb();
  	return true;
  }
  
-@@ -10456,7 +10465,7 @@ static inline void mm_update_cpus_allowed(struct mm_struct *mm, const struct cpu
+@@ -10456,7 +10471,7 @@ static inline void mm_update_cpus_allowed(struct mm_struct *mm, const struct cpu
  
  	WRITE_ONCE(mc->nr_cpus_allowed, weight);
  	__mm_update_max_cids(mc);
@@ -200,45 +204,44 @@ index bd86e4bd0cd7..64999332076f 100644
  		return;
  
  	/* Adjust the threshold to the wider set */
-@@ -10517,8 +10526,8 @@ static void mm_cid_fixup_cpus_to_tasks(struct mm_struct *mm)
+@@ -10474,6 +10489,16 @@ static inline void mm_update_cpus_allowed(struct mm_struct *mm, const struct cpu
+ 	irq_work_queue(&mc->irq_work);
+ }
+ 
++static inline void mm_cid_complete_transit(struct mm_struct *mm, unsigned int mode)
++{
++	/*
++	 * Ensure that the store removing the TRANSIT bit cannot be
++	 * reordered by the CPU before the fixups have been completed.
++	 */
++	smp_mb();
++	WRITE_ONCE(mm->mm_cid.mode, mode);
++}
++
+ static inline void mm_cid_transit_to_task(struct task_struct *t, struct mm_cid_pcpu *pcp)
+ {
+ 	if (cid_on_cpu(t->mm_cid.cid)) {
+@@ -10517,8 +10542,7 @@ static void mm_cid_fixup_cpus_to_tasks(struct mm_struct *mm)
  			}
  		}
  	}
 -	/* Clear the transition bit */
 -	WRITE_ONCE(mm->mm_cid.transit, 0);
-+	/* Clear the transition bit in the mode */
-+	WRITE_ONCE(mm->mm_cid.mode, 0);
++	mm_cid_complete_transit(mm, 0);
  }
  
  static inline void mm_cid_transit_to_cpu(struct task_struct *t, struct mm_cid_pcpu *pcp)
-@@ -10546,9 +10555,8 @@ static bool mm_cid_fixup_task_to_cpu(struct task_struct *t, struct mm_struct *mm
- 	return true;
+@@ -10590,8 +10614,7 @@ static void mm_cid_fixup_tasks_to_cpus(void)
+ 	struct mm_struct *mm = current->mm;
+ 
+ 	mm_cid_do_fixup_tasks_to_cpus(mm);
+-	/* Clear the transition bit */
+-	WRITE_ONCE(mm->mm_cid.transit, 0);
++	mm_cid_complete_transit(mm, MM_CID_ONCPU);
  }
  
--static void mm_cid_fixup_tasks_to_cpus(void)
-+static void mm_cid_do_fixup_tasks_to_cpus(struct mm_struct *mm)
- {
--	struct mm_struct *mm = current->mm;
- 	struct task_struct *p, *t;
- 	unsigned int users;
- 
-@@ -10586,6 +10594,15 @@ static void mm_cid_fixup_tasks_to_cpus(void)
- 	}
- }
- 
-+static void mm_cid_fixup_tasks_to_cpus(void)
-+{
-+	struct mm_struct *mm = current->mm;
-+
-+	mm_cid_do_fixup_tasks_to_cpus(mm);
-+	/* Clear the transition bit in the mode */
-+	WRITE_ONCE(mm->mm_cid.mode, MM_CID_ONCPU);
-+}
-+
  static bool sched_mm_cid_add_user(struct task_struct *t, struct mm_struct *mm)
- {
- 	t->mm_cid.active = 1;
-@@ -10614,13 +10631,13 @@ void sched_mm_cid_fork(struct task_struct *t)
+@@ -10622,13 +10645,13 @@ void sched_mm_cid_fork(struct task_struct *t)
  		}
  
  		if (!sched_mm_cid_add_user(t, mm)) {
@@ -254,16 +257,7 @@ index bd86e4bd0cd7..64999332076f 100644
  		if (!percpu)
  			mm_cid_transit_to_task(current, pcp);
  		else
-@@ -10629,8 +10646,6 @@ void sched_mm_cid_fork(struct task_struct *t)
- 
- 	if (percpu) {
- 		mm_cid_fixup_tasks_to_cpus();
--		/* Clear the transition bit */
--		WRITE_ONCE(mm->mm_cid.transit, 0);
- 	} else {
- 		mm_cid_fixup_cpus_to_tasks(mm);
- 		t->mm_cid.cid = mm_get_cid(mm);
-@@ -10661,7 +10676,7 @@ static bool __sched_mm_cid_exit(struct task_struct *t)
+@@ -10667,7 +10690,7 @@ static bool __sched_mm_cid_exit(struct task_struct *t)
  	 * affinity change increased the number of allowed CPUs and the
  	 * deferred fixup did not run yet.
  	 */
@@ -272,7 +266,7 @@ index bd86e4bd0cd7..64999332076f 100644
  		return false;
  	/*
  	 * A failed fork(2) cleanup never gets here, so @current must have
-@@ -10752,7 +10767,7 @@ static void mm_cid_work_fn(struct work_struct *work)
+@@ -10758,7 +10781,7 @@ static void mm_cid_work_fn(struct work_struct *work)
  		if (!mm_update_max_cids(mm))
  			return;
  		/* Affinity changes can only switch back to task mode */
@@ -281,7 +275,7 @@ index bd86e4bd0cd7..64999332076f 100644
  			return;
  	}
  	mm_cid_fixup_cpus_to_tasks(mm);
-@@ -10773,8 +10788,7 @@ static void mm_cid_irq_work(struct irq_work *work)
+@@ -10779,8 +10802,7 @@ static void mm_cid_irq_work(struct irq_work *work)
  void mm_init_cid(struct mm_struct *mm, struct task_struct *p)
  {
  	mm->mm_cid.max_cids = 0;

--- a/ci/diffs/202602023-sched-mmcid-Drop-per-CPU-CID-immediately-when-s.patch
+++ b/ci/diffs/202602023-sched-mmcid-Drop-per-CPU-CID-immediately-when-s.patch
@@ -1,11 +1,11 @@
-From 73fad52a0c324c219927db6b430a57aecee45607 Mon Sep 17 00:00:00 2001
+From 3f2e95ba4a663b7d57b662d69a689b73be1db25d Mon Sep 17 00:00:00 2001
 From: Thomas Gleixner <tglx@kernel.org>
-Date: Thu, 29 Jan 2026 22:20:52 +0100
-Subject: [PATCH 202601293/202601294] sched/mmcid: Drop per CPU CID immediately
+Date: Mon, 2 Feb 2026 10:39:50 +0100
+Subject: [PATCH 202602023/202602024] sched/mmcid: Drop per CPU CID immediately
  when switching to per task mode
 
 When a exiting task initiates the switch from per CPU back to per task
-mode, it has already dropped it's CID and marked itself inactive. But a
+mode, it has already dropped its CID and marked itself inactive. But a
 leftover from an earlier iteration of the rework then reassigns the per
 CPU CID to the exiting task with the transition bit set.
 
@@ -18,15 +18,16 @@ Simply drop the per CPU CID when the exiting task triggered the transition.
 
 Fixes: fbd0e71dc370 ("sched/mmcid: Provide CID ownership mode fixup functions")
 Signed-off-by: Thomas Gleixner <tglx@kernel.org>
+Reviewed-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
 ---
  kernel/sched/core.c | 10 ++++++++--
  1 file changed, 8 insertions(+), 2 deletions(-)
 
 diff --git a/kernel/sched/core.c b/kernel/sched/core.c
-index 64999332076f..29114f972d88 100644
+index f429ff4eb84c..93421141da5b 100644
 --- a/kernel/sched/core.c
 +++ b/kernel/sched/core.c
-@@ -10709,8 +10709,14 @@ void sched_mm_cid_exit(struct task_struct *t)
+@@ -10723,8 +10723,14 @@ void sched_mm_cid_exit(struct task_struct *t)
  			scoped_guard(raw_spinlock_irq, &mm->mm_cid.lock) {
  				if (!__sched_mm_cid_exit(t))
  					return;

--- a/ci/diffs/202602024-sched-mmcid-Optimize-transitional-CIDs-when-sch.patch
+++ b/ci/diffs/202602024-sched-mmcid-Optimize-transitional-CIDs-when-sch.patch
@@ -1,7 +1,7 @@
-From a8df30f884230bc8be1a58029e15073795e85cf0 Mon Sep 17 00:00:00 2001
+From 0753080bd26e8209d870106ac3bd1d80454c1399 Mon Sep 17 00:00:00 2001
 From: Thomas Gleixner <tglx@kernel.org>
-Date: Thu, 29 Jan 2026 22:20:54 +0100
-Subject: [PATCH 202601294/202601294] sched/mmcid: Optimize transitional CIDs
+Date: Mon, 2 Feb 2026 10:39:55 +0100
+Subject: [PATCH 202602024/202602024] sched/mmcid: Optimize transitional CIDs
  when scheduling out
 
 During the investigation of the various transition mode issues
@@ -13,10 +13,11 @@ At that point the mode is stable and therefore it is not required to drop
 the transitional CID back into the pool. As the fixup is complete the
 potential exhaustion of the CID pool is not longer possible, so the CID can
 be transferred to the scheduling out task or to the CPU depending on the
-current ownership mode. This is now possible because mm_cid::mode contains
-both the ownership state and the transition bit so the racy snapshot is
-valid under all circumstances because a subsequent modification of the
-mode is serialized by the corresponding runqueue lock.
+current ownership mode.
+
+The racy snapshot of mm_cid::mode which contains both the ownership state
+and the transition bit is valid because runqueue lock is held and the fixup
+function of a concurrent mode switch is serialized.
 
 Assigning the ownership right there not only spares the bitmap access for
 dropping the CID it also avoids it when the task is scheduled back in as it
@@ -31,15 +32,16 @@ boundaries frequently this reduces the number of bitmap operations by about
 percentage range.
 
 Signed-off-by: Thomas Gleixner <tglx@linutronix.de>
+Reviewed-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
 ---
- kernel/sched/sched.h | 24 ++++++++++++++++++++++--
- 1 file changed, 22 insertions(+), 2 deletions(-)
+ kernel/sched/sched.h | 23 +++++++++++++++++++++--
+ 1 file changed, 21 insertions(+), 2 deletions(-)
 
 diff --git a/kernel/sched/sched.h b/kernel/sched/sched.h
-index ecf2281e3545..7bcf31889dd3 100644
+index ecf2281e3545..70b595dbf227 100644
 --- a/kernel/sched/sched.h
 +++ b/kernel/sched/sched.h
-@@ -3879,12 +3879,32 @@ static __always_inline void mm_cid_schedin(struct task_struct *next)
+@@ -3879,12 +3879,31 @@ static __always_inline void mm_cid_schedin(struct task_struct *next)
  
  static __always_inline void mm_cid_schedout(struct task_struct *prev)
  {
@@ -57,8 +59,7 @@ index ecf2281e3545..7bcf31889dd3 100644
 +
 +	/*
 +	 * If transition mode is done, transfer ownership when the CID is
-+	 * within the convergion range. Otherwise the next schedule in will
-+	 * have to allocate or converge
++	 * within the convergence range to optimize the next schedule in.
 +	 */
 +	if (!cid_in_transit(mode) && cid < READ_ONCE(mm->mm_cid.max_cids)) {
 +		if (cid_on_cpu(mode))


### PR DESCRIPTION
Add a fix for selftests/sched_ext:
https://lore.kernel.org/sched-ext/03982d7b5642c0ad003668178f9e5df7@kernel.org/

Update sched/mmcid patches to v2:
https://lore.kernel.org/all/20260201192234.380608594@kernel.org/