### PR TITLE
Tune down instance-size for AI review and gcc-bpf

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on:
       - ${{ format('codebuild-bpf-ci-{0}-{1}', github.run_id, github.run_attempt) }}
       - image:custom-linux-ghcr.io/kernel-patches/runner:ai-review
-      - instance-size:xlarge
+      - instance-size:large
     strategy:
       matrix:
         commit: ${{ fromJson(needs.get-commits.outputs.commits) }}

--- a/.github/workflows/gcc-bpf.yml
+++ b/.github/workflows/gcc-bpf.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on:
       - ${{ format('codebuild-bpf-ci-{0}-{1}', github.run_id, github.run_attempt) }}
       - image:custom-linux-ghcr.io/kernel-patches/runner:kbuilder-debian-x86_64
+      - instance-size:large
     env:
       ARCH: ${{ inputs.arch }}
       BPF_NEXT_BASE_BRANCH: 'master'


### PR DESCRIPTION
Both AI review and gcc-bpf aren't compute intensive on the runner side, so there is no reason to use xlarge (default) for these jobs.

For reference [1]:
  - xlarge is 36 vCPUs / 72 GiB
  - large is 8 vCPUs / 16 GiB

[1] https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html