### PR TITLE
ci/vmtest/configs: Fitler out scx v1.0.18 lavd_enqueue from veristat-…

### DIFF
--- a/ci/vmtest/configs/veristat_meta.cfg
+++ b/ci/vmtest/configs/veristat_meta.cfg
@@ -44,3 +44,8 @@
 # We can include them back after a veristat release with fixed libbpf
 !third-party-scx-__scx_chaos_bpf_skel_genskel-bpf.bpf.o
 !third-party-scx-__scx_p2dq_bpf_skel_genskel-bpf.bpf.o
+
+# scx v1.0.18 lavd_enqueue fails verification. Pin the exclusion to this
+# version so newer scx releases, which are expected to be fixed, still signal
+# failures instead of being silently skipped.
+!third-party-scx-v1.0.18-__scx_lavd_bpf_skel_genskel-bpf.bpf.o/lavd_enqueue


### PR DESCRIPTION
…meta

lavd_enqueue in third-party-scx-v1.0.18-__scx_lavd_bpf_skel_genskel-bpf.bpf.o fails verification due to recent fix in the verifier [1].

The offending kfunc is going to be removed in v7.3 [2], and newer versions of the scheduler will be adapted. Filter out the failing program from CI to reduce noise.

[1] https://lore.kernel.org/bpf/20260707190214.1997705-1-memxor@gmail.com
[2] https://lore.kernel.org/sched-ext/20260619155920.156257-1-christian.loehle@arm.com/

Reported-by: Kumar Kartikeya Dwivedi <memxor@gmail.com>