### PR TITLE
ci: ai-code-review: preserve ci/ across the source move

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -94,12 +94,20 @@ jobs:
           FETCH_DEPTH: 100
 
       # This manipulation is necessary to make sure that
-      # ${{ github.workspace }} is the root of the Linux git repo
+      # ${{ github.workspace }} is the root of the Linux git repo.
+      #
+      # The AI review config lives in ci/, which is present on every *_base
+      # branch and thus in this checkout (the pull_request merge ref), but not
+      # necessarily in the PR head tree fetched above (get-linux-source pulls
+      # head.sha only). Preserve the checked-out ci/ across the move instead of
+      # deleting it, dropping only the head tree's own ci/ to avoid a collision,
+      # so the config is available regardless of whether the head carries it.
       - name: Move linux source in place
         shell: bash
         run: |
-          rm -rf .git .github ci
+          rm -rf .git .github
           cd .kernel
+          rm -rf ci
           mv -t .. $(ls -A)
           cd ..
           rmdir .kernel


### PR DESCRIPTION
The AI review config (ci/claude/) lives on every *_base branch, so it is present in the pull_request checkout that actions/checkout uses by default (the merge ref, head merged into base). But "Move linux source in place" ran `rm -rf .git .github ci` and then overlaid the PR *head* tree fetched separately by get-linux-source (head.sha only, not the merge). Series whose head does not carry ci/ -- built on a base without the injection, or manual branches -- thus lost the config, and the claude-code-action step failed with:

  Error: Invalid MCP configuration:
  MCP config file not found: .../ci/claude/mcp.json

The same post-move loss would break ci/claude/post-pr-comment.js, which the "Comment on PR" step requires later.

Keep the checked-out ci/ across the move (drop only the head tree's own ci/ to avoid a collision) so the config is available regardless of whether the head carries it. No config duplication or inlining needed; ci/claude/*.json stays the single source of truth, consistent with ai-agent.yml, whose move does not delete ci/ and was never affected.