### PR TITLE
ci: Denylist libarena parallel tests on s390x

### DIFF
--- a/ci/vmtest/configs/DENYLIST.s390x
+++ b/ci/vmtest/configs/DENYLIST.s390x
@@ -8,3 +8,4 @@ sock_iter_batch/udp                        # SO_REUSEPORT bind(0) port collision
 tc_edt
 tc_tunnel/ip6gre*                          # connect() 1000ms too short for IPv6 neigh resolution under emulation; vmtest#483
 wq                                         # usleep(50) too short under emulation; vmtest#455
+libarena/parallel_test_*                   # in-BPF spin barriers time out under emulation; same class as arena_spin_lock


### PR DESCRIPTION

The libarena parallel selftests spawn several threads, each running one
BPF syscall program, and rendezvous them with a spin barrier inside BPF:

  run_libarena_parallel_test:FAIL:parallel_test_bitmap unexpected error: -110

The barrier cannot wait indefinitely - BPF loops must be bounded, and on
architectures with timed may_goto support the effective budget is a 250ms
wall clock deadline. That budget is wall clock, but what it is waiting for
is CPU work on a peer thread, and emulation stretches that work by orders
of magnitude while leaving the deadline unchanged. The barrier therefore
times out long before the peer gets to run.

Beyond the timeout, an emulated VM cannot provide the real concurrency
these tests exist to exercise, so running them there produces noise rather
than coverage. This is the same reasoning behind the arena_spin_lock and
res_spin_lock_stress entries already in this list.

Only the parallel subtests are denied. The serial libarena subtests keep
running and still cover the s390 JIT's atomic instruction generation
(bmp_test_and_set_bit() and friends compile down to cmpxchg on arena
memory), so no JIT coverage is lost.

https://github.com/kernel-patches/bpf/actions/runs/30407571610/job/90439350390
https://github.com/kernel-patches/bpf/actions/runs/30407371815/job/90438295786
https://github.com/kernel-patches/bpf/actions/runs/30407309576/job/90438238976
https://github.com/kernel-patches/bpf/actions/runs/30407232425/job/90437839166
