### PR TITLE
kernel-test: normalize traffic monitor log names before uploading

### DIFF
--- a/.github/workflows/kernel-test.yml
+++ b/.github/workflows/kernel-test.yml
@@ -94,6 +94,22 @@ jobs:
           # it was extracted from the artifacts.
           kbuild-output: ${{ env.REPO_ROOT }}/kbuild-output
 
+      # run-vmtest normalizes these names itself, but it does so after the VM
+      # exits, so a timeout or a dead VM kills the step before it gets there.
+      # The upload below runs regardless, so redo it here to be safe.
+      - if: ${{ always() }}
+        name: Normalize traffic monitor log names
+        shell: bash
+        run: |
+          dir=/tmp/tmon_pcap
+          [ -d "$dir" ] || exit 0
+          find "$dir" -depth -name '*[":<>|*?]*' -print0 |
+          while IFS= read -r -d '' path; do
+            base=$(basename "$path")
+            new="$(dirname "$path")/$(printf '%s' "$base" | tr '":<>|*?\r\n' '_________')"
+            [ "$path" = "$new" ] || mv -v -- "$path" "$new"
+          done
+
       - if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
The traffic monitor names its logs after the test and subtest, so they can contain characters that actions/upload-artifact rejects. A subtest called "INET4: bpf_timestamping" makes the upload fail as below (see [1])

  Error: The path for one of the files in artifact is not valid:
  /packets-125-15-net_timestamping__INET4:_bpf_timestamping-net_timestamping_ns.log.
  Contains the following character:  Colon :

run-vmtest already renames these, but only after the VM exits, so a step timeout or a dead VM kills it before that point. The upload step runs with if: always() and then trips over the names that were left behind.

Rename them in a step of its own, also guarded by if: always(), so it happens whatever the outcome of the test step. It is a no-op when the directory is absent, which is the case for every test that does not enable the traffic monitor, and re-running it is harmless.

Link: https://github.com/kernel-patches/vmtest/actions/runs/30710914503/job/9139901138 [1]