### PR TITLE
ci: point setup-build-env at the cross-sysroot branch

### DIFF
--- a/.github/workflows/gcc-bpf.yml
+++ b/.github/workflows/gcc-bpf.yml
@@ -75,7 +75,7 @@ jobs:
         run: zstd -d -T0 vmlinux-${{ inputs.arch }}-${{ inputs.toolchain_full }}.tar.zst --stdout | tar -xf -
 
       - name: Setup build environment
-        uses: libbpf/ci/setup-build-env@v4
+        uses: libbpf/ci/setup-build-env@cross-sysroot
         with:
           arch: ${{ inputs.arch }}
           gcc-version: ${{ inputs.gcc_version }}

--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -104,7 +104,7 @@ jobs:
           repo-root: ${{ env.REPO_ROOT }}
 
       - name: Setup build environment
-        uses: libbpf/ci/setup-build-env@v4
+        uses: libbpf/ci/setup-build-env@cross-sysroot
         with:
           arch: ${{ inputs.arch }}
           gcc-version: ${{ inputs.gcc_version }}

--- a/.github/workflows/test-progs-asan.yml
+++ b/.github/workflows/test-progs-asan.yml
@@ -68,7 +68,7 @@ jobs:
           repo-root: ${{ env.REPO_ROOT }}
 
       - name: Setup build environment
-        uses: libbpf/ci/setup-build-env@v4
+        uses: libbpf/ci/setup-build-env@cross-sysroot
         with:
           arch: ${{ inputs.arch }}
           gcc-version: ${{ inputs.gcc_version }}


### PR DESCRIPTION
Not for merge. Exercises libbpf/ci's cross-sysroot branch, which unpacks the target libraries into the cross toolchain's sysroot instead of installing them as multiarch packages, so s390x builds survive Debian's glibc / cross-toolchain-base skew.

Revert to @v4 before merging anything from this branch.