### PR TITLE
ci: own the kernel splat matching

### DIFF
--- a/.github/workflows/kernel-test.yml
+++ b/.github/workflows/kernel-test.yml
@@ -100,3 +100,12 @@ jobs:
           name: tmon-logs-${{ inputs.arch }}-${{ inputs.toolchain_full }}-${{ inputs.test }}
           if-no-files-found: ignore
           path: /tmp/tmon_pcap/*
+
+      # Written by check-kernel-splats.sh inside the VM, into the bind-mounted
+      # workspace. Needed to triage a splat, and to audit the scan itself.
+      - if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: kernel-log-${{ inputs.arch }}-${{ inputs.toolchain_full }}-${{ inputs.test }}
+          if-no-files-found: ignore
+          path: dmesg.txt

--- a/ci/vmtest/configs/SPLAT_ALLOWLIST
+++ b/ci/vmtest/configs/SPLAT_ALLOWLIST
@@ -1,0 +1,21 @@
+# Kernel splats that check-kernel-splats.sh must not fail the run on.
+#
+# One extended regex per line, matched against the dmesg line. `#` comments
+# and blank lines are ignored.
+#
+# Every entry is a hole in the scan, so give each one a reason and a link, and
+# delete it once the fix reaches the CI kernel. An entry with no expiry is a
+# bug that CI has agreed to stop reporting.
+#
+# The selftest config leaves unprivileged BPF on (CONFIG_BPF_UNPRIV_DEFAULT_OFF
+# is not set in tools/testing/selftests/bpf/config), so the Spectre v2 code
+# warns about it on every boot on x86_64, and whenever a test writes the sysctl
+# on arm64. It states a config choice, not a kernel bug.
+WARNING: Unprivileged eBPF is enabled
+
+# arm64 stack unwinder writes past the entry array while KASAN saves a free
+# stack, so any kfree() under test_progs reports stack-out-of-bounds. Not a BPF
+# bug; BPF only walks that path often. Fix posted 2026-08-12:
+# https://lore.kernel.org/all/20260812-hello_world-v1-1-c3c2ddcb362d@meta.com/
+# Delete this entry once that fix reaches the CI kernel.
+BUG: KASAN: stack-out-of-bounds in (stack_trace_consume_entry|filter_irq_stacks)\+

--- a/ci/vmtest/configs/SPLAT_DENYLIST
+++ b/ci/vmtest/configs/SPLAT_DENYLIST
@@ -1,0 +1,24 @@
+# Kernel splat signatures for check-kernel-splats.sh. A dmesg line matching
+# any of these fails the run.
+#
+# One extended regex per line. `#` comments and blank lines are ignored. This
+# file is required: with no patterns there is no check, so the action fails the
+# run rather than reporting a clean log.
+#
+# `^(\[[^]]*\] *)*` eats the timestamp and the CONFIG_PRINTK_CALLER field, so a
+# pattern holds for `dmesg`, for `dmesg -t` and for both configs.
+
+# `BUG:` covers KASAN, KCSAN, KMSAN and KFENCE. `WARNING:` covers __warn(), and
+# with it lockdep, refcount_t and list corruption, which all print through
+# WARN(). An oops panics the VM (PANIC_ON_OOPS plus panic=-1), which fails the
+# job on its own, so it needs no pattern here.
+^(\[[^]]*\] *)*(BUG|WARNING|UBSAN|Oops)[: ]
+^(\[[^]]*\] *)*kernel BUG at
+
+# kernel/watchdog.c sets pr_fmt, so a lockup line starts with `watchdog: `,
+# not with `BUG:`.
+^(\[[^]]*\] *)*watchdog: .*(soft lockup|hard LOCKUP)
+
+# kernel/rcu/tree.c sets pr_fmt to "rcu: ", which hides the INFO: from an
+# anchored match.
+^(\[[^]]*\] *)*(rcu: )?INFO: (task .* blocked for more than|[_a-z]+ (self-)?detected stall)

--- a/ci/vmtest/configs/run-vmtest.env
+++ b/ci/vmtest/configs/run-vmtest.env
@@ -41,3 +41,10 @@ DENYLIST_FILES=(
 # Export pipe-separated strings, because bash doesn't support array export
 export SELFTESTS_BPF_ALLOWLIST_FILES=$(IFS="|"; echo "${ALLOWLIST_FILES[*]}")
 export SELFTESTS_BPF_DENYLIST_FILES=$(IFS="|"; echo "${DENYLIST_FILES[*]}")
+
+# Kernel splat matching for check-kernel-splats.sh. The denylist says what a
+# splat is, the allowlist drops the matches that are benign for this CI. The
+# action carries no patterns of its own, so a change to either costs one PR to
+# this repo, and no libbpf/ci sync.
+export SPLAT_DENYLIST_FILE="${VMTEST_CONFIGS}/SPLAT_DENYLIST"
+export SPLAT_ALLOWLIST_FILE="${VMTEST_CONFIGS}/SPLAT_ALLOWLIST"


### PR DESCRIPTION
libbpf/ci gained a post-test dmesg scan that fails a run on a kernel splat. The action carries no patterns: what a splat is, and what is benign here, differs per arch and per kernel, so both lists live in this repo, where a change costs one PR and no sync.

Also upload the dmesg the scan captures, which is what a splat report is triaged from.
