### PR TITLE
disable ksock_lsm on bpf-gcc

### DIFF
--- a/ci/vmtest/configs/DENYLIST.test_progs-bpf_gcc
+++ b/ci/vmtest/configs/DENYLIST.test_progs-bpf_gcc
@@ -96,6 +96,7 @@ global_percpu_data		# crashing kernel: bad .percpu address
 inner_array_lookup
 iters/iter_err_unsafe_asm_loop
 kfree_skb
+ksock_lsm
 l4lb_all/l4lb_noinline
 l4lb_all/l4lb_noinline_dynptr
 linked_list


### PR DESCRIPTION
ksock_lsm.c test was introduced as a part of a series [1]. This series landed on Sat Aug 15 2026.
As it turns out, the test breaks on the CI when compiled by gcc [2].

Here is exact verification failure:

0: R1=ctx() R10=fp0
;  @ ksock_lsm.c:25185
0: (81) r6 = *(s32 *)(r1 +24)         ; R1=ctx() R6=scalar(smin=0xffffffff80000000,smax=0x7fffffff)
;  @ ksock_lsm.c:55
1: (85) call bpf_get_current_pid_tgid#14      ; R0=scalar()
;  @ ksock_lsm.c:57
2: (55) if r6 != 0x0 goto pc+5 8: R6=scalar(smin=0xffffffff80000000,smax=0x7fffffff) R10=fp0
;  @ ksock_lsm.c:51
8: (bf) r0 = r6                       ; R0=scalar(id=4,smin=0xffffffff80000000,smax=0x7fffffff) R6=scalar(id=4,smin=0xffffffff80000000,smax=0x7fffffff)
9: (95) exit

Kumar Kartikeya Dwivedi figured out the error is in interaction of lsm context processing in reg->type == PTR_TO_CTX branch of check_mem_access() (which set's the range for 'ret' variable), and further coerce_reg_to_size_sx().

Disable the test on the CI for bpf-gcc for now to unblock the pipelines.

[1] https://lore.kernel.org/bpf/178683001639.93126.16574683717755052782.git-patchwork-notify@kernel.org/T/#t
[2] https://productionresultssa0.blob.core.windows.net/actions-results/fc9fa40c-4cb7-46fa-b7f4-ff00c2d718a3/workflow-job-run-da2a312e-6025-5916-a484-184a613b1230/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-08-16T04%3A25%3A10Z&sig=VS75N2Oli5ti63jJTy75IPE0hHSasK%2FkdUq35c5IBOY%3D&ske=2026-08-16T06%3A06%3A30Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-08-16T02%3A06%3A30Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-08-16T04%3A15%3A05Z&sv=2025-11-05