### PR TITLE
[RFC] kernel-build.yaml: add an action to test bpftool build

### DIFF
--- a/.github/workflows/build-bpftool.yml
+++ b/.github/workflows/build-bpftool.yml
@@ -1,0 +1,54 @@
+name: Test bpftool build methods
+
+on:
+  workflow_call:
+    inputs:
+      download_sources:
+        required: true
+        type: boolean
+        description: Whether to download the linux sources into the working directory.
+
+jobs:
+  build-bpftool:
+    name: Test bpftool build
+    runs-on: ubuntu-latest
+    env:
+      BPF_NEXT_BASE_BRANCH: 'master'
+      REPO_ROOT: ${{ github.workspace }}/src
+    steps:
+
+      - if: ${{ inputs.download_sources }}
+        name: Download bpf-next tree
+        uses: libbpf/ci/get-linux-source@v4
+        with:
+          dest: ${{ env.REPO_ROOT }}
+          rev: ${{ env.BPF_NEXT_BASE_BRANCH }}
+
+      - if: ${{ ! inputs.download_sources }}
+        name: Checkout ${{ github.repository }} to ./src
+        uses: actions/checkout@v6
+        with:
+          path: 'src'
+
+      - name: Install bpftool build dependencies
+        shell: bash
+        run: |
+          # libreadline is needed by tools/bpf (bpf_dbg); libelf, libcap,
+          # zlib and libbfd are needed by bpftool itself; llvm provides
+          # llvm-strip, used to strip the skeleton BPF objects (clang is
+          # already preinstalled on the runner)
+          sudo apt-get update
+          sudo -E apt-get install --no-install-recommends -y \
+              libelf-dev libcap-dev binutils-dev zlib1g-dev libreadline-dev llvm
+
+      - name: Build bpftool
+        shell: bash
+        run: |
+          test_script="${REPO_ROOT}/tools/testing/selftests/bpf/test_bpftool_build.sh"
+          if [ ! -e "${test_script}" ]; then
+              echo "skip: test_bpftool_build.sh not found in kernel sources" >&2
+              exit 0
+          fi
+          cd "${REPO_ROOT}"
+          bash "${test_script}" -j 32
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,3 +76,9 @@ jobs:
       is_netdev: ${{ matrix.is_netdev }}
     secrets:
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+
+  build-bpftool:
+    name: Test bpftool build
+    uses: ./.github/workflows/build-bpftool.yml
+    with:
+      download_sources: ${{ github.repository == 'kernel-patches/vmtest' }}


### PR DESCRIPTION
The tools/testing/selftests/bpf directory in the kernel source tree contains the test_bpftool_build.sh script that ensures that the various supported ways of building bpftool work correctly. This test isn't currently part of the tests automatically executed in CI.

Add a dedicated step in kernel-build.yml to execute this script and validate that bpftool can be built correctly.

:warning: Depends on https://github.com/libbpf/ci/pull/236

An execution example can be found here: https://github.com/kernel-patches/bpf/pull/13368

See RFC on mailing list: https://lore.kernel.org/bpf/DKT6QBHWC8YM.4D90SOC807CW@bootlin.com/