### PR TITLE
disable stream read tests on bpf-gcc

### DIFF
--- a/ci/vmtest/configs/DENYLIST.test_progs-bpf_gcc
+++ b/ci/vmtest/configs/DENYLIST.test_progs-bpf_gcc
@@ -137,6 +137,8 @@ sockmap_basic/sockmap copy
 sockmap_strp			# flaky
 spin_lock
 stream_arena_fault_address
+stream_oversize
+stream_partial_read
 stream_success/stream_arena_subprog_fault
 stream_syscall
 struct_ops_arena/arena_arg


### PR DESCRIPTION
`stream_oversize` and `stream_partial_read` both load the shared stream
skeleton. When the BPF programs are compiled with GCC, skeleton loading
reaches `stream_arena_subprog_fault` and fails verification before either
test reaches its intended checks:

```
Verification failed: Register Type Safety: Invalid dereference
error: invalid dereference of R2 (an integer scalar)
```

Temporarily add both top-level tests to
`DENYLIST.test_progs-bpf_gcc`, following the existing exclusions for the
incompatible stream programs.

Observed in:

- https://github.com/kernel-patches/bpf/pull/13411
- https://github.com/kernel-patches/bpf/actions/runs/32645868984/job/97211792284
- https://github.com/kernel-patches/bpf/actions/runs/32645868984/job/97212115728
