### PR TITLE
ci: add a new workflow to test bpftool build

### DIFF
--- a/.github/workflows/build-bpftool.yml
+++ b/.github/workflows/build-bpftool.yml
@@ -1,0 +1,46 @@
+name: Test bpftool build methods
+
+on:
+  workflow_call:
+    inputs:
+      download_sources:
+        required: true
+        type: boolean
+        description: Whether to download the linux sources into the working directory.
+
+jobs:
+  build-bpftool:
+    name: Test bpftool build
+    timeout-minutes: 10
+    permissions: read-all
+    runs-on: ubuntu-latest
+    env:
+      BPF_NEXT_BASE_BRANCH: 'master'
+      REPO_ROOT: ${{ github.workspace }}/src
+    steps:
+      - if: ${{ inputs.download_sources }}
+        name: Download bpf-next tree
+        uses: libbpf/ci/get-linux-source@v4
+        with:
+          dest: ${{ env.REPO_ROOT }}
+          rev: ${{ env.BPF_NEXT_BASE_BRANCH }}
+      - if: ${{ ! inputs.download_sources }}
+        name: Checkout ${{ github.repository }} to ./src
+        uses: actions/checkout@v6
+        with:
+          path: 'src'
+      - name: Install bpftool build dependencies
+        shell: bash
+        run: |
+          # libreadline is needed by tools/bpf (bpf_dbg); libelf, libcap,
+          # zlib and libbfd are needed by bpftool itself; llvm provides
+          # llvm-strip, used to strip the skeleton BPF objects (clang is
+          # already preinstalled on the runner)
+          sudo apt-get update
+          sudo -E apt-get install --no-install-recommends -y \
+              libelf-dev libcap-dev binutils-dev zlib1g-dev libreadline-dev llvm
+      - name: Test
+        shell: bash
+        run: |
+          cd "${REPO_ROOT}"
+          bash ./tools/testing/selftests/bpf/test_bpftool_build.sh -j "$(nproc)"

--- a/.github/workflows/test-build-commands.yml
+++ b/.github/workflows/test-build-commands.yml
@@ -1,0 +1,15 @@
+name: Test build commands
+
+on:
+  workflow_call:
+    inputs:
+      download_sources:
+        required: true
+        type: boolean
+        description: Whether to download the linux sources into the working directory.
+
+jobs:
+  bpftool:
+    uses: ./.github/workflows/build-bpftool.yml
+    with:
+      download_sources: ${{ inputs.download_sources }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,3 +76,9 @@ jobs:
       is_netdev: ${{ matrix.is_netdev }}
     secrets:
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+
+  test-build-commands:
+    name: Test build commands
+    uses: ./.github/workflows/test-build-commands.yml
+    with:
+      download_sources: ${{ github.repository == 'kernel-patches/vmtest' }}


### PR DESCRIPTION
The tools/testing/selftests/bpf directory in the kernel source tree contains the test_bpftool_build.sh script that ensures that the various supported ways of building bpftool work correctly. This test isn't currently part of the tests automatically executed in CI.

Add a new layer of workflows in test.yml to run tests that will exercise build commands. As a first sub-workflow, add a bpftool build workflow:
  test.yml -> test-build-commands.yml -> build->bpftool.yml
This test-build-commands workflow can be extended later to support other artifacts build test, for example to test the different ways of building selftests.

The new build-bpftool workflow aims to validate the different ways of building the bpftool CLI, as exercised by the test_bpftool_build.sh in the kernel source tree (in tools/testing/selftests/bpf). As the test has only a few dependencies (only a build test, no dependency on built artifact), the added workflow remains simple and isolated from the other "build-and-tests" workflows:
- it only tests host build, so no need to run it as many time as the matrix script generates configurations
- supports download_sources flag, so can be run from kernel tree or vmtest tree


---
This new workflow does not make the whole test_bpftool_build.sh execute in CI; as some subtests are gated by the presence of a .config. I suspect this to be hiding a broader kbuild issue as bpftool does not really depend on .config, I'll fix this separately in another series.